### PR TITLE
[XS] Rename MarketToken name for branding consistency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: "1.0.0"
 
       - name: Install dependencies
         run: |

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -14,6 +14,7 @@ export type BaseMarketConfig = {
   openInterestReserveFactorShorts?: BigNumberish;
 
   minCollateralFactor: BigNumberish;
+  minMaintainCollateralFactor?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplier?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierLong?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierShort?: BigNumberish;
@@ -252,6 +253,7 @@ const borrowingRateConfig_HighMax_WithHigherBase: BorrowingRateConfig = {
 
 const baseMarketConfig: Partial<BaseMarketConfig> = {
   minCollateralFactor: percentageToFloat("1%"), // 1%
+  minMaintainCollateralFactor: percentageToFloat("0.5%"), // 0.5% (liquidation threshold)
 
   minCollateralFactorForOpenInterestMultiplier: 0,
 

--- a/contracts/market/MarketToken.sol
+++ b/contracts/market/MarketToken.sol
@@ -9,7 +9,7 @@ import "../bank/Bank.sol";
 // @dev The market token for a market, stores funds for the market and keeps track
 // of the liquidity owners
 contract MarketToken is ERC20, Bank {
-    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("GMX Market", "GM") Bank(_roleStore, _dataStore) {
+    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarkets Market", "0xM") Bank(_roleStore, _dataStore) {
     }
 
     // @dev mint market tokens to an account

--- a/contracts/market/MarketToken.sol
+++ b/contracts/market/MarketToken.sol
@@ -9,7 +9,7 @@ import "../bank/Bank.sol";
 // @dev The market token for a market, stores funds for the market and keeps track
 // of the liquidity owners
 contract MarketToken is ERC20, Bank {
-    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarkets Market", "0xM") Bank(_roleStore, _dataStore) {
+    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarket", "0xM") Bank(_roleStore, _dataStore) {
     }
 
     // @dev mint market tokens to an account

--- a/scripts/updateMarketConfigUtils.ts
+++ b/scripts/updateMarketConfigUtils.ts
@@ -299,7 +299,7 @@ const processMarkets = async ({
       "uint",
       keys.MIN_MAINTAIN_COLLATERAL_FACTOR,
       encodeData(["address"], [marketToken]),
-      marketConfig.minMaintainCollateralFactor,
+      marketConfig.minMaintainCollateralFactor ?? marketConfig.minCollateralFactor,
       `minMaintainCollateralFactor ${marketLabel} (${marketToken})`
     );
 


### PR DESCRIPTION
https://generaltaoventures.atlassian.net/jira/software/projects/DEX/boards/141?selectedIssue=DEX-173

rename GM tokens visible in user wallets to 0xM so that all token naming is consistent with the 0xMarkets