### PR TITLE
Dynamic MMR liquidation mechanism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: "1.0.0"
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GMX Synthetics
+# 0xMarkets
 
-Contracts for GMX Synthetics.
+Contracts for 0xMarkets.
 
 # General Overview
 
@@ -87,10 +87,6 @@ Majority of data is stored using the DataStore contract.
 EnumberableSets are used to allow order lists and position lists to be easily queried by interfaces or keepers, this is used over indexers as there may be a lag for indexers to sync the latest block. Having the lists stored directly in the contract also helps to ensure that accurate data can be retrieved and verified when needed.
 
 \*eventUtils contracts emit events using the event emitter, the events are generalized to allow new key-values to be added to events without requiring an update of ABIs.
-
-## GLV
-
-Short for GMX Liquidity Vault: a wrapper of multiple markets with the same long and short tokens. Liquidity is automatically rebalanced between underlying markets based on markets utilisation.
 
 # Technical Overview
 
@@ -636,19 +632,9 @@ After the initial setup:
 
 - There is a dependency on the accuracy of the block timestamp because oracle prices are validated against this value, for blockchains where the blockchain nodes have some control over the timestamp, care should be taken to set the oracleTimestampAdjustment to a value that would make manipulation of the timestamp unprofitable
 
-## GLV
-
-- The GLV shift feature can be exploited by temporarily increasing the utilization in a market that typically has low utilization. Once the keeper executes the shift, the attacker can lower the utilization back to its normal levels. Position fees and price impact should be configured in a way that makes this attack expensive enough to cover the GLV loss.
-
-- In GLV there may be GM markets which are above their maximum pnlToPoolFactorForTraders. If this GM market's maxPnlFactorForDeposits is higher than maxPnlFactorForTraders then the GM market is valued lower during deposits than it will be once traders have realized their capped profits. Malicious user may observe a GM market in such a condition and deposit into the GLV containing it in order to gain from ADLs which will soon follow. To avoid this maxPnlFactorForDeposits should be less than or equal to maxPnlFactorForTraders.
-
-- It's technically possible for market value to become negative. In this case the GLV would be unusable until the market value becomes positive.
-
-- GM tokens could become illiquid due to high pnl factor or high reserved usd. Users can deposit illiquid GM tokens into GVL and withdraw liquidity from a different market, leaving the GLV with illiquid tokens. The glvMaxMarketTokenBalanceUsd and glvMaxMarketTokenBalanceAmount parameters should account for the riskiness of a market to avoid having too many GM tokens from a risky market.
-
 ## Factories
 
-- Upon adding a Market with the MarketStoreUtils.set function, the Market is given a lookup where the Market address can be obtained with the Market salt. This lookup is not cleared upon market deletion. The same applies to GLV.
+- Upon adding a Market with the MarketStoreUtils.set function, the Market is given a lookup where the Market address can be obtained with the Market salt. This lookup is not cleared upon market deletion.
 
 # Notes
 
@@ -665,7 +651,7 @@ After the initial setup:
 
 - If new contracts are added that may lead to a difference in pricing, e.g. of market tokens between the old and new contracts, then care should be taken to disable the old contracts before the new contracts are enabled
 
-- Any external protocols that use the Reader contract or potentially outdated calculations for pricing should be reminded to use the latest contracts and calculations, e.g. Chainlink price feeds for GM tokens
+- Any external protocols that use the Reader contract or potentially outdated calculations for pricing should be reminded to use the latest contracts and calculations, e.g. Chainlink price feeds for market tokens
 
 - It is recommended to publish a best effort Changelog documenting important changes that integrations should be aware about, e.g. if a field is added to a struct that is passed into a callback function, this change may not be obvious to integrations
 
@@ -709,7 +695,7 @@ After the initial setup:
 
 - While the code has been structured to minimize the risk of [read-only reentrancy](https://officercia.mirror.xyz/DBzFiDuxmDOTQEbfXhvLdK0DXVpKu1Nkurk0Cqk3QKc), care should be taken to guard against this possibility
 
-- Token airdrops may occur to the accounts of GM token holders, integrating contracts holding GM tokens must be able to claim these tokens otherwise the tokens would be locked, the exact implementation for this will vary depending on the integrating contract, one possibility is to allow claiming of tokens that are not market tokens, this can be checked using the `Keys.MARKET_LIST` value
+- Token airdrops may occur to the accounts of market token holders, integrating contracts holding market tokens must be able to claim these tokens otherwise the tokens would be locked, the exact implementation for this will vary depending on the integrating contract, one possibility is to allow claiming of tokens that are not market tokens, this can be checked using the `Keys.MARKET_LIST` value
 
 - ETH transfers are sent with NATIVE_TOKEN_TRANSFER_GAS_LIMIT for the gas limit, if the transfer fails due to insufficient gas or other errors, the ETH is sent as WETH instead
 
@@ -747,7 +733,7 @@ After the initial setup:
 
 ### Deposits
 
-- Consider PnL Factor when estimating GM price
+- Consider PnL Factor when estimating market token price
 
 - Handle deposit cancellations
 

--- a/config/buyback.ts
+++ b/config/buyback.ts
@@ -45,7 +45,8 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<BuybackC
     localhost: defaultEmptyConfig,
   };
 
-  const networkConfig: BuybackConfig = config[hre.network.name];
+  const networkConfig: BuybackConfig =
+    config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
 
   return networkConfig;
 }

--- a/config/general.ts
+++ b/config/general.ts
@@ -154,7 +154,7 @@ export default async function ({ network }: HardhatRuntimeEnvironment) {
       feeReceiver: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       holdingAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     },
-  }[network.name];
+  }[network.name === "baseSepoliaFork" ? "baseSepolia" : network.name];
 
   if (!networkConfig) {
     throw new Error(`Network config not defined for ${network.name}`);

--- a/config/general.ts
+++ b/config/general.ts
@@ -151,8 +151,8 @@ export default async function ({ network }: HardhatRuntimeEnvironment) {
       estimatedGasPerOraclePrice: false,
       executionGasFeeBaseAmount: false,
       executionGasPerOraclePrice: false,
-      feeReceiver: "REPLACE_ME",
-      holdingAddress: "REPLACE_ME",
+      feeReceiver: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      holdingAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     },
   }[network.name];
 

--- a/config/glvs.ts
+++ b/config/glvs.ts
@@ -31,7 +31,7 @@ export default async function ({ network }: HardhatRuntimeEnvironment) {
     baseSepolia: [],
     hardhat: [],
     localhost: [],
-  }[network.name]!;
+  }[network.name === "baseSepoliaFork" ? "baseSepolia" : network.name]!;
 
   if (!config) {
     throw new Error(`Network config not defined for ${network.name}`);

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -552,28 +552,18 @@ const config: {
   ],
   localhost: [
     {
-      tokens: { indexToken: "EUR", longToken: "USDC", shortToken: "USDC" },
-      reversed: false,
-    },
-    {
-      tokens: { indexToken: "GBP", longToken: "USDC", shortToken: "USDC" },
-      reversed: false,
-    },
-    {
-      tokens: { indexToken: "GOLD", longToken: "USDC", shortToken: "USDC" },
-      reversed: false,
-    },
-    {
-      tokens: { indexToken: "JPY", longToken: "USDC", shortToken: "USDC" },
-      reversed: true,
-    },
-    {
-      tokens: { indexToken: "WBTC", longToken: "USDC", shortToken: "USDC" },
-      reversed: false,
-    },
-    {
       tokens: { indexToken: "WETH", longToken: "USDC", shortToken: "USDC" },
       reversed: false,
+      maxLongTokenPoolAmount: expandDecimals(1_000_000_000, 6),
+      maxShortTokenPoolAmount: expandDecimals(1_000_000_000, 6),
+      maxLongTokenPoolUsdForDeposit: decimalToFloat(1_000_000_000),
+      maxShortTokenPoolUsdForDeposit: decimalToFloat(1_000_000_000),
+      maxOpenInterest: decimalToFloat(1_000_000_000),
+      maxPnlFactorForTraders: decimalToFloat(5, 1),
+      maxPnlFactorForAdl: decimalToFloat(45, 2),
+      minPnlFactorAfterAdl: decimalToFloat(4, 1),
+      maxPnlFactorForDeposits: decimalToFloat(6, 1),
+      maxPnlFactorForWithdrawals: decimalToFloat(3, 1),
     },
   ],
 };

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -14,6 +14,7 @@ export type BaseMarketConfig = {
   openInterestReserveFactorShorts?: BigNumberish;
 
   minCollateralFactor: BigNumberish;
+  minMaintainCollateralFactor?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplier?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierLong?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierShort?: BigNumberish;
@@ -252,6 +253,7 @@ const borrowingRateConfig_HighMax_WithHigherBase: BorrowingRateConfig = {
 
 const baseMarketConfig: Partial<BaseMarketConfig> = {
   minCollateralFactor: percentageToFloat("1%"), // 1%
+  minMaintainCollateralFactor: percentageToFloat("0.5%"), // 0.5% (liquidation threshold)
 
   minCollateralFactorForOpenInterestMultiplier: 0,
 

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -266,8 +266,9 @@ const baseMarketConfig: Partial<BaseMarketConfig> = {
   // the trader can absorb ~50% of collateral loss before liquidation:
   //   mmr_tuning = 0.5 / maxLeverage
   // At low leverage, min_mmr floors the required buffer.
+  // min_leverage is opt-in (0 = no lower bound). Set it per-market to enforce.
   maxLeverage: decimalToFloat(50), // conservative default for markets without an asset-class override
-  minLeverage: decimalToFloat(1),
+  minLeverage: 0,
   minMmr: percentageToFloat("0.3%"),
   maxMmr: percentageToFloat("10%"),
   mmrTuning: percentageToFloat("1%"), // 0.5 / 50x
@@ -388,7 +389,7 @@ const fxMarketOverrides: Partial<BaseMarketConfig> = {
   minMaintainCollateralFactor: percentageToFloat("0.1333%"),
 
   maxLeverage: decimalToFloat(500),
-  minLeverage: decimalToFloat(1),
+  minLeverage: 0,
   minMmr: percentageToFloat("0.1%"),
   maxMmr: percentageToFloat("10%"),
   mmrTuning: percentageToFloat("0.1%"), // 0.5 / 500x
@@ -401,7 +402,7 @@ const commodityMarketOverrides: Partial<BaseMarketConfig> = {
   minMaintainCollateralFactor: percentageToFloat("0.3333%"),
 
   maxLeverage: decimalToFloat(200),
-  minLeverage: decimalToFloat(1),
+  minLeverage: 0,
   minMmr: percentageToFloat("0.2%"),
   maxMmr: percentageToFloat("10%"),
   mmrTuning: percentageToFloat("0.25%"), // 0.5 / 200x
@@ -414,7 +415,7 @@ const cryptoMarketOverrides: Partial<BaseMarketConfig> = {
   minMaintainCollateralFactor: percentageToFloat("0.6666%"),
 
   maxLeverage: decimalToFloat(100),
-  minLeverage: decimalToFloat(1),
+  minLeverage: 0,
   minMmr: percentageToFloat("0.3%"),
   maxMmr: percentageToFloat("10%"),
   mmrTuning: percentageToFloat("0.5%"), // 0.5 / 100x
@@ -437,12 +438,17 @@ const hardhatBaseMarketConfig: Partial<BaseMarketConfig> = {
   minCollateralFactor: percentageToFloat("1%"), // 1%
   minMaintainCollateralFactor: percentageToFloat("1%"), // 1%
 
-  // Dynamic MMR defaults for hardhat
-  maxLeverage: decimalToFloat(50),
-  minLeverage: decimalToFloat(1),
-  minMmr: percentageToFloat("0.5%"),
+  // Dynamic MMR defaults for hardhat — 100x cap + 1% min_mmr replicate the legacy
+  // `minMaintainCollateralFactor = 1%` flat MMR that existing tests were written against.
+  // Under the new formula, tuning 0.5% at max leverage is below the 1% floor, so MMR
+  // clamps to 1% across all leverages — effectively flat, matching old behavior.
+  // Prod markets (fx/commodity/crypto) use sub-floor tuning to expose the dynamic curve.
+  // min_leverage stays 0 (opt-in); tests that want the lower-bound gate set it per-market.
+  maxLeverage: decimalToFloat(100),
+  minLeverage: 0,
+  minMmr: percentageToFloat("1%"),
   maxMmr: percentageToFloat("10%"),
-  mmrTuning: percentageToFloat("1%"), // 0.5 / 50x
+  mmrTuning: percentageToFloat("0.5%"), // 0.5 / 100x
 
   minCollateralFactorForOpenInterestMultiplier: 0,
 

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -19,6 +19,13 @@ export type BaseMarketConfig = {
   minCollateralFactorForOpenInterestMultiplierLong?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierShort?: BigNumberish;
 
+  // Dynamic MMR parameters. mmr = clamp((sizeInUsd/collateralUsd)/maxLeverage * mmrTuning, minMmr, maxMmr)
+  maxLeverage?: BigNumberish;
+  minLeverage?: BigNumberish;
+  minMmr?: BigNumberish;
+  maxMmr?: BigNumberish;
+  mmrTuning?: BigNumberish;
+
   maxLongTokenPoolAmount: BigNumberish;
   maxShortTokenPoolAmount: BigNumberish;
 
@@ -253,7 +260,17 @@ const borrowingRateConfig_HighMax_WithHigherBase: BorrowingRateConfig = {
 
 const baseMarketConfig: Partial<BaseMarketConfig> = {
   minCollateralFactor: percentageToFloat("1%"), // 1%
-  minMaintainCollateralFactor: percentageToFloat("0.5%"), // 0.5% (liquidation threshold)
+  minMaintainCollateralFactor: percentageToFloat("0.5%"), // 0.5% (liquidation threshold, legacy — superseded by dynamic MMR)
+
+  // Dynamic MMR defaults. Sized so that at currLeverage == maxLeverage,
+  // the trader can absorb ~50% of collateral loss before liquidation:
+  //   mmr_tuning = 0.5 / maxLeverage
+  // At low leverage, min_mmr floors the required buffer.
+  maxLeverage: decimalToFloat(50), // conservative default for markets without an asset-class override
+  minLeverage: decimalToFloat(1),
+  minMmr: percentageToFloat("0.3%"),
+  maxMmr: percentageToFloat("10%"),
+  mmrTuning: percentageToFloat("1%"), // 0.5 / 50x
 
   minCollateralFactorForOpenInterestMultiplier: 0,
 
@@ -364,12 +381,17 @@ const synthethicMarketConfig_IncreasedCapacity: Partial<BaseMarketConfig> = {
   maxPnlFactorForWithdrawals: percentageToFloat("55%"),
 };
 
-// Asset-class-specific overrides (position fees + collateral factors for leverage limits)
 const fxMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForPositiveImpact: percentageToFloat("0.01%"),
   positionFeeFactorForNegativeImpact: percentageToFloat("0.015%"),
   minCollateralFactor: percentageToFloat("0.1333%"), // 500x max leverage
   minMaintainCollateralFactor: percentageToFloat("0.1333%"),
+
+  maxLeverage: decimalToFloat(500),
+  minLeverage: decimalToFloat(1),
+  minMmr: percentageToFloat("0.1%"),
+  maxMmr: percentageToFloat("10%"),
+  mmrTuning: percentageToFloat("0.1%"), // 0.5 / 500x
 };
 
 const commodityMarketOverrides: Partial<BaseMarketConfig> = {
@@ -377,6 +399,12 @@ const commodityMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForNegativeImpact: percentageToFloat("0.01%"),
   minCollateralFactor: percentageToFloat("0.3333%"), // 200x max leverage
   minMaintainCollateralFactor: percentageToFloat("0.3333%"),
+
+  maxLeverage: decimalToFloat(200),
+  minLeverage: decimalToFloat(1),
+  minMmr: percentageToFloat("0.2%"),
+  maxMmr: percentageToFloat("10%"),
+  mmrTuning: percentageToFloat("0.25%"), // 0.5 / 200x
 };
 
 const cryptoMarketOverrides: Partial<BaseMarketConfig> = {
@@ -384,6 +412,12 @@ const cryptoMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForNegativeImpact: percentageToFloat("0.025%"),
   minCollateralFactor: percentageToFloat("0.6666%"), // 100x max leverage
   minMaintainCollateralFactor: percentageToFloat("0.6666%"),
+
+  maxLeverage: decimalToFloat(100),
+  minLeverage: decimalToFloat(1),
+  minMmr: percentageToFloat("0.3%"),
+  maxMmr: percentageToFloat("10%"),
+  mmrTuning: percentageToFloat("0.5%"), // 0.5 / 100x
 };
 
 const stablecoinSwapMarketConfig: Partial<SpotMarketConfig> = {
@@ -402,6 +436,14 @@ const hardhatBaseMarketConfig: Partial<BaseMarketConfig> = {
 
   minCollateralFactor: percentageToFloat("1%"), // 1%
   minMaintainCollateralFactor: percentageToFloat("1%"), // 1%
+
+  // Dynamic MMR defaults for hardhat
+  maxLeverage: decimalToFloat(50),
+  minLeverage: decimalToFloat(1),
+  minMmr: percentageToFloat("0.5%"),
+  maxMmr: percentageToFloat("10%"),
+  mmrTuning: percentageToFloat("1%"), // 0.5 / 50x
+
   minCollateralFactorForOpenInterestMultiplier: 0,
 
   maxLongTokenPoolAmount: expandDecimals(1_000_000_000, 18),

--- a/config/markets.ts
+++ b/config/markets.ts
@@ -13,8 +13,6 @@ export type BaseMarketConfig = {
   openInterestReserveFactorLongs?: BigNumberish;
   openInterestReserveFactorShorts?: BigNumberish;
 
-  minCollateralFactor: BigNumberish;
-  minMaintainCollateralFactor?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplier?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierLong?: BigNumberish;
   minCollateralFactorForOpenInterestMultiplierShort?: BigNumberish;
@@ -259,9 +257,6 @@ const borrowingRateConfig_HighMax_WithHigherBase: BorrowingRateConfig = {
 };
 
 const baseMarketConfig: Partial<BaseMarketConfig> = {
-  minCollateralFactor: percentageToFloat("1%"), // 1%
-  minMaintainCollateralFactor: percentageToFloat("0.5%"), // 0.5% (liquidation threshold, legacy — superseded by dynamic MMR)
-
   // Dynamic MMR defaults. Sized so that at currLeverage == maxLeverage,
   // the trader can absorb ~50% of collateral loss before liquidation:
   //   mmr_tuning = 0.5 / maxLeverage
@@ -385,8 +380,6 @@ const synthethicMarketConfig_IncreasedCapacity: Partial<BaseMarketConfig> = {
 const fxMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForPositiveImpact: percentageToFloat("0.01%"),
   positionFeeFactorForNegativeImpact: percentageToFloat("0.015%"),
-  minCollateralFactor: percentageToFloat("0.1333%"), // 500x max leverage
-  minMaintainCollateralFactor: percentageToFloat("0.1333%"),
 
   maxLeverage: decimalToFloat(500),
   minLeverage: 0,
@@ -398,8 +391,6 @@ const fxMarketOverrides: Partial<BaseMarketConfig> = {
 const commodityMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForPositiveImpact: percentageToFloat("0.005%"),
   positionFeeFactorForNegativeImpact: percentageToFloat("0.01%"),
-  minCollateralFactor: percentageToFloat("0.3333%"), // 200x max leverage
-  minMaintainCollateralFactor: percentageToFloat("0.3333%"),
 
   maxLeverage: decimalToFloat(200),
   minLeverage: 0,
@@ -411,8 +402,6 @@ const commodityMarketOverrides: Partial<BaseMarketConfig> = {
 const cryptoMarketOverrides: Partial<BaseMarketConfig> = {
   positionFeeFactorForPositiveImpact: percentageToFloat("0.02%"),
   positionFeeFactorForNegativeImpact: percentageToFloat("0.025%"),
-  minCollateralFactor: percentageToFloat("0.6666%"), // 100x max leverage
-  minMaintainCollateralFactor: percentageToFloat("0.6666%"),
 
   maxLeverage: decimalToFloat(100),
   minLeverage: 0,
@@ -435,13 +424,8 @@ const hardhatBaseMarketConfig: Partial<BaseMarketConfig> = {
   reserveFactor: decimalToFloat(5, 1), // 50%,
   openInterestReserveFactor: decimalToFloat(5, 1), // 50%,
 
-  minCollateralFactor: percentageToFloat("1%"), // 1%
-  minMaintainCollateralFactor: percentageToFloat("1%"), // 1%
-
-  // Dynamic MMR defaults for hardhat — 100x cap + 1% min_mmr replicate the legacy
-  // `minMaintainCollateralFactor = 1%` flat MMR that existing tests were written against.
-  // Under the new formula, tuning 0.5% at max leverage is below the 1% floor, so MMR
-  // clamps to 1% across all leverages — effectively flat, matching old behavior.
+  // Dynamic MMR defaults for hardhat — 100x cap + 1% min_mmr give tests a flat 1%
+  // effective MMR across all leverages (tuning 0.5% at max is below the floor).
   // Prod markets (fx/commodity/crypto) use sub-floor tuning to expose the dynamic curve.
   // min_leverage stays 0 (opt-in); tests that want the lower-bound gate set it per-market.
   maxLeverage: decimalToFloat(100),
@@ -719,7 +703,7 @@ function fillLongShortValues(market, key, longKey, shortKey) {
 }
 
 export default async function (hre: HardhatRuntimeEnvironment) {
-  const markets = config[hre.network.name];
+  const markets = config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
   const tokens = await hre.gmx.getTokens();
   const defaultMarketConfig = hre.network.name === "hardhat" ? hardhatBaseMarketConfig : baseMarketConfig;
   if (markets) {

--- a/config/oracle.ts
+++ b/config/oracle.ts
@@ -60,7 +60,7 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<OracleCo
     },
   };
 
-  const oracleConfig: OracleConfig = config[hre.network.name];
+  const oracleConfig: OracleConfig = config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
 
   return oracleConfig;
 }

--- a/config/overwrite.ts
+++ b/config/overwrite.ts
@@ -6,5 +6,5 @@ export function getExistingContractAddresses(network) {
     hardhat: {},
   };
 
-  return config[network.name];
+  return config[network.name === "baseSepoliaFork" ? "baseSepolia" : network.name];
 }

--- a/config/riskOracle.ts
+++ b/config/riskOracle.ts
@@ -23,7 +23,8 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<RiskOrac
     localhost: {},
   };
 
-  const riskOracleConfig: RiskOracleConfig = config[hre.network.name];
+  const riskOracleConfig: RiskOracleConfig =
+    config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
 
   if (riskOracleConfig.markets) {
     for (const [marketAddress, marketConfig] of Object.entries(riskOracleConfig.markets)) {

--- a/config/roles.ts
+++ b/config/roles.ts
@@ -126,8 +126,9 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<RolesCon
     }
   }
 
+  const networkName = hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name;
   return {
-    roles: roles[hre.network.name],
+    roles: roles[networkName],
     requiredRolesForContracts,
   };
 }

--- a/config/tokens.ts
+++ b/config/tokens.ts
@@ -348,7 +348,7 @@ async function getAssetAddress(hre, key: string) {
 }
 
 export default async function (hre: HardhatRuntimeEnvironment): Promise<TokensConfig> {
-  const tokens = config[hre.network.name];
+  const tokens = config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
 
   for (const [tokenSymbol, token] of Object.entries(tokens as TokensConfig)) {
     (token as any).symbol = tokenSymbol;

--- a/config/tokens.ts
+++ b/config/tokens.ts
@@ -270,22 +270,6 @@ const config: {
     },
   },
   localhost: {
-    EUR: {
-      decimals: 6,
-      isAsset: true,
-    },
-    GBP: {
-      decimals: 6,
-      isAsset: true,
-    },
-    GOLD: {
-      decimals: 6,
-      isAsset: true,
-    },
-    JPY: {
-      decimals: 6,
-      isAsset: true,
-    },
     USDC: {
       decimals: 6,
       transferGasLimit: 200 * 1000,
@@ -294,17 +278,6 @@ const config: {
         heartbeatDuration: 24 * 60 * 60,
         deploy: true,
         initPrice: "100000000",
-      },
-      deploy: true,
-    },
-    WBTC: {
-      decimals: 8,
-      transferGasLimit: 200 * 1000,
-      priceFeed: {
-        decimals: 8,
-        heartbeatDuration: 24 * 60 * 60,
-        deploy: true,
-        initPrice: "10000000000000",
       },
       deploy: true,
     },

--- a/config/vaultV1.ts
+++ b/config/vaultV1.ts
@@ -22,7 +22,8 @@ export default async function (hre: HardhatRuntimeEnvironment): Promise<VaultV1C
     },
   };
 
-  const vaultV1Config: VaultV1Config = config[hre.network.name];
+  const vaultV1Config: VaultV1Config =
+    config[hre.network.name === "baseSepoliaFork" ? "baseSepolia" : hre.network.name];
 
   return vaultV1Config;
 }

--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -512,6 +512,11 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         allowedBaseKeys[Keys.REQUEST_EXPIRATION_TIME] = true;
         allowedBaseKeys[Keys.MIN_COLLATERAL_FACTOR] = true;
         allowedBaseKeys[Keys.MIN_MAINTAIN_COLLATERAL_FACTOR] = true;
+        allowedBaseKeys[Keys.MAX_LEVERAGE] = true;
+        allowedBaseKeys[Keys.MIN_LEVERAGE] = true;
+        allowedBaseKeys[Keys.MIN_MMR] = true;
+        allowedBaseKeys[Keys.MAX_MMR] = true;
+        allowedBaseKeys[Keys.MMR_TUNING] = true;
         allowedBaseKeys[Keys.MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER] = true;
         allowedBaseKeys[Keys.MIN_COLLATERAL_USD] = true;
 

--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -510,8 +510,6 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         allowedBaseKeys[Keys.NATIVE_TOKEN_TRANSFER_GAS_LIMIT] = true;
 
         allowedBaseKeys[Keys.REQUEST_EXPIRATION_TIME] = true;
-        allowedBaseKeys[Keys.MIN_COLLATERAL_FACTOR] = true;
-        allowedBaseKeys[Keys.MIN_MAINTAIN_COLLATERAL_FACTOR] = true;
         allowedBaseKeys[Keys.MAX_LEVERAGE] = true;
         allowedBaseKeys[Keys.MIN_LEVERAGE] = true;
         allowedBaseKeys[Keys.MIN_MMR] = true;
@@ -723,8 +721,7 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
             baseKey == Keys.FUNDING_FACTOR ||
             baseKey == Keys.BORROWING_FACTOR ||
             baseKey == Keys.FUNDING_INCREASE_FACTOR_PER_SECOND ||
-            baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND ||
-            baseKey == Keys.MIN_COLLATERAL_FACTOR
+            baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND
         ) {
             // revert if value > 1%
             if (value > (1 * Precision.FLOAT_PRECISION) / 100) {

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -264,6 +264,16 @@ library Keys {
     bytes32 public constant MIN_COLLATERAL_FACTOR = keccak256(abi.encode("MIN_COLLATERAL_FACTOR"));
     // @dev key for the min maintain collateral factor
     bytes32 public constant MIN_MAINTAIN_COLLATERAL_FACTOR = keccak256(abi.encode("MIN_MAINTAIN_COLLATERAL_FACTOR"));
+    // @dev key for the max allowed leverage per market (used as denominator in dynamic MMR)
+    bytes32 public constant MAX_LEVERAGE = keccak256(abi.encode("MAX_LEVERAGE"));
+    // @dev key for the min allowed leverage per market
+    bytes32 public constant MIN_LEVERAGE = keccak256(abi.encode("MIN_LEVERAGE"));
+    // @dev key for the lower clamp of the dynamic maintenance margin ratio
+    bytes32 public constant MIN_MMR = keccak256(abi.encode("MIN_MMR"));
+    // @dev key for the upper clamp of the dynamic maintenance margin ratio
+    bytes32 public constant MAX_MMR = keccak256(abi.encode("MAX_MMR"));
+    // @dev key for the tuning multiplier applied to the leverage ratio in the dynamic MMR formula
+    bytes32 public constant MMR_TUNING = keccak256(abi.encode("MMR_TUNING"));
     // @dev key for the min collateral factor for open interest multiplier
     bytes32 public constant MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER = keccak256(abi.encode("MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER"));
     // @dev key for the min allowed collateral in USD
@@ -1042,6 +1052,51 @@ library Keys {
    function minMaintainCollateralFactorKey(address market) internal pure returns (bytes32) {
        return keccak256(abi.encode(
            MIN_MAINTAIN_COLLATERAL_FACTOR,
+           market
+       ));
+   }
+
+   // @dev the max leverage key
+   // @param market the market for the max leverage
+   function maxLeverageKey(address market) internal pure returns (bytes32) {
+       return keccak256(abi.encode(
+           MAX_LEVERAGE,
+           market
+       ));
+   }
+
+   // @dev the min leverage key
+   // @param market the market for the min leverage
+   function minLeverageKey(address market) internal pure returns (bytes32) {
+       return keccak256(abi.encode(
+           MIN_LEVERAGE,
+           market
+       ));
+   }
+
+   // @dev the min mmr key 
+   // @param market the market for the min mmr
+   function minMmrKey(address market) internal pure returns (bytes32) {
+       return keccak256(abi.encode(
+           MIN_MMR,
+           market
+       ));
+   }
+
+   // @dev the max mmr key
+   // @param market the market for the max mmr
+   function maxMmrKey(address market) internal pure returns (bytes32) {
+       return keccak256(abi.encode(
+           MAX_MMR,
+           market
+       ));
+   }
+
+   // @dev the mmr tuning key
+   // @param market the market for the mmr tuning
+   function mmrTuningKey(address market) internal pure returns (bytes32) {
+       return keccak256(abi.encode(
+           MMR_TUNING,
            market
        ));
    }

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -260,10 +260,6 @@ library Keys {
     bytes32 public constant REFUND_EXECUTION_FEE_GAS_LIMIT = keccak256(abi.encode("REFUND_EXECUTION_FEE_GAS_LIMIT"));
     bytes32 public constant SAVED_CALLBACK_CONTRACT = keccak256(abi.encode("SAVED_CALLBACK_CONTRACT"));
 
-    // @dev key for the min collateral factor
-    bytes32 public constant MIN_COLLATERAL_FACTOR = keccak256(abi.encode("MIN_COLLATERAL_FACTOR"));
-    // @dev key for the min maintain collateral factor
-    bytes32 public constant MIN_MAINTAIN_COLLATERAL_FACTOR = keccak256(abi.encode("MIN_MAINTAIN_COLLATERAL_FACTOR"));
     // @dev key for the max allowed leverage per market (used as denominator in dynamic MMR)
     bytes32 public constant MAX_LEVERAGE = keccak256(abi.encode("MAX_LEVERAGE"));
     // @dev key for the min allowed leverage per market
@@ -1034,24 +1030,6 @@ library Keys {
        return keccak256(abi.encode(
            SAVED_CALLBACK_CONTRACT,
            account,
-           market
-       ));
-   }
-
-   // @dev the min collateral factor key
-   // @param the market for the min collateral factor
-   function minCollateralFactorKey(address market) internal pure returns (bytes32) {
-       return keccak256(abi.encode(
-           MIN_COLLATERAL_FACTOR,
-           market
-       ));
-   }
-
-   // @dev the min maintain collateral factor key
-   // @param the market for the min maintain collateral factor
-   function minMaintainCollateralFactorKey(address market) internal pure returns (bytes32) {
-       return keccak256(abi.encode(
-           MIN_MAINTAIN_COLLATERAL_FACTOR,
            market
        ));
    }

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -297,7 +297,8 @@ library Errors {
         string reason,
         int256 remainingCollateralUsd,
         int256 minCollateralUsd,
-        int256 minCollateralUsdForLeverage
+        int256 requiredCollateralUsd,
+        uint256 mmr
     );
 
     // IncreasePositionUtils errors
@@ -312,12 +313,14 @@ library Errors {
         string reason,
         int256 remainingCollateralUsd,
         int256 minCollateralUsd,
-        int256 minCollateralUsdForLeverage
+        int256 requiredCollateralUsd,
+        uint256 mmr
     );
 
     error EmptyPosition();
     error InvalidPositionSizeValues(uint256 sizeInUsd, uint256 sizeInTokens);
     error MinPositionSize(uint256 positionSizeInUsd, uint256 minPositionSizeUsd);
+    error InvalidLeverage(uint256 currLeverage, uint256 minLeverage);
 
     // PositionPricingUtils errors
     error UsdDeltaExceedsLongOpenInterest(int256 usdDelta, uint256 longOpenInterest);

--- a/contracts/market/MarketToken.sol
+++ b/contracts/market/MarketToken.sol
@@ -9,7 +9,7 @@ import "../bank/Bank.sol";
 // @dev The market token for a market, stores funds for the market and keeps track
 // of the liquidity owners
 contract MarketToken is ERC20, Bank {
-    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("GMX Market", "GM") Bank(_roleStore, _dataStore) {
+    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarkets Market", "0xM") Bank(_roleStore, _dataStore) {
     }
 
     // @dev mint market tokens to an account

--- a/contracts/market/MarketToken.sol
+++ b/contracts/market/MarketToken.sol
@@ -9,7 +9,7 @@ import "../bank/Bank.sol";
 // @dev The market token for a market, stores funds for the market and keeps track
 // of the liquidity owners
 contract MarketToken is ERC20, Bank {
-    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarkets Market", "0xM") Bank(_roleStore, _dataStore) {
+    constructor(RoleStore _roleStore, DataStore _dataStore) ERC20("0xMarket", "0xM") Bank(_roleStore, _dataStore) {
     }
 
     // @dev mint market tokens to an account

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -1898,6 +1898,81 @@ library MarketUtils {
         return dataStore.getUint(Keys.minMaintainCollateralFactorKey(market));
     }
 
+    // @dev get the max leverage allowed for the market
+    // @param dataStore DataStore
+    // @param market the market to check
+    function getMaxLeverage(DataStore dataStore, address market) internal view returns (uint256) {
+        return dataStore.getUint(Keys.maxLeverageKey(market));
+    }
+
+    // @dev get the min leverage allowed for the market
+    // @param dataStore DataStore
+    // @param market the market to check
+    function getMinLeverage(DataStore dataStore, address market) internal view returns (uint256) {
+        return dataStore.getUint(Keys.minLeverageKey(market));
+    }
+
+    // @dev get the lower clamp of the dynamic MMR
+    // @param dataStore DataStore
+    // @param market the market to check
+    function getMinMmr(DataStore dataStore, address market) internal view returns (uint256) {
+        return dataStore.getUint(Keys.minMmrKey(market));
+    }
+
+    // @dev get the upper clamp of the dynamic MMR
+    // @param dataStore DataStore
+    // @param market the market to check
+    function getMaxMmr(DataStore dataStore, address market) internal view returns (uint256) {
+        return dataStore.getUint(Keys.maxMmrKey(market));
+    }
+
+    // @dev get the tuning multiplier applied to the leverage ratio in the dynamic MMR formula
+    // @param dataStore DataStore
+    // @param market the market to check
+    function getMmrTuning(DataStore dataStore, address market) internal view returns (uint256) {
+        return dataStore.getUint(Keys.mmrTuningKey(market));
+    }
+
+    // @dev compute the dynamic maintenance margin ratio (MMR) for a position
+    // MMR scales with the position's leverage at its last modification:
+    //   currLeverage = sizeInUsd / collateralUsd
+    //   rawMmr       = (currLeverage / maxLeverage) * mmrTuning
+    //   mmr          = clamp(rawMmr, minMmr, maxMmr)
+    // @param dataStore DataStore
+    // @param market the market address
+    // @param sizeInUsd the position's size in USD
+    // @param collateralUsd the position's collateral in USD as of its last modification
+    // @return the dynamic MMR as a factor
+    function getDynamicMmr(
+        DataStore dataStore,
+        address market,
+        uint256 sizeInUsd,
+        uint256 collateralUsd
+    ) internal view returns (uint256) {
+        uint256 maxLeverage = getMaxLeverage(dataStore, market);
+        uint256 mmrTuning = getMmrTuning(dataStore, market);
+        uint256 minMmr = getMinMmr(dataStore, market);
+        uint256 maxMmr = getMaxMmr(dataStore, market);
+
+        // Defensive: a post-validation position cannot have zero collateral, but
+        // if one ever reaches here it is unambiguously liquidatable.
+        if (collateralUsd == 0 || maxLeverage == 0) {
+            return maxMmr;
+        }
+
+        uint256 currLeverage = Precision.toFactor(sizeInUsd, collateralUsd);
+        uint256 leverageRatio = Precision.toFactor(currLeverage, maxLeverage);
+        uint256 rawMmr = Precision.applyFactor(leverageRatio, mmrTuning);
+
+        if (rawMmr < minMmr) {
+            return minMmr;
+        }
+        if (rawMmr > maxMmr) {
+            return maxMmr;
+        }
+        return rawMmr;
+    }
+
     // @dev get the min collateral factor for open interest multiplier
     // @param dataStore DataStore
     // @param market the market to check

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -1884,20 +1884,6 @@ library MarketUtils {
         return dataStore.getUint(Keys.maxPositionImpactFactorForLiquidationsKey(market));
     }
 
-    // @dev get the min collateral factor
-    // @param dataStore DataStore
-    // @param market the market to check
-    function getMinCollateralFactor(DataStore dataStore, address market) internal view returns (uint256) {
-        return dataStore.getUint(Keys.minCollateralFactorKey(market));
-    }
-
-    // @dev get the min maintain collateral factor
-    // @param dataStore DataStore
-    // @param market the market to check
-    function getMinMaintainCollateralFactor(DataStore dataStore, address market) internal view returns (uint256) {
-        return dataStore.getUint(Keys.minMaintainCollateralFactorKey(market));
-    }
-
     // @dev get the max leverage allowed for the market
     // @param dataStore DataStore
     // @param market the market to check

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -1954,10 +1954,18 @@ library MarketUtils {
         uint256 minMmr = getMinMmr(dataStore, market);
         uint256 maxMmr = getMaxMmr(dataStore, market);
 
-        // Defensive: a post-validation position cannot have zero collateral, but
-        // if one ever reaches here it is unambiguously liquidatable.
-        if (collateralUsd == 0 || maxLeverage == 0) {
+        // Defensive: if maxLeverage is misconfigured (0), fall back to the hard
+        // ceiling — the position cannot be validated under any sensible ratio.
+        if (maxLeverage == 0) {
             return maxMmr;
+        }
+
+        // Transient zero-collateral states occur during fee deduction inside a
+        // decrease flow (fees eat the entire collateral; PnL covers the rest).
+        // Returning `minMmr` here lets validatePosition pass when PnL can cover
+        // the minimum required buffer, and still fails otherwise.
+        if (collateralUsd == 0) {
+            return minMmr;
         }
 
         uint256 currLeverage = Precision.toFactor(sizeInUsd, collateralUsd);

--- a/contracts/mock/MockPythLazer.sol
+++ b/contracts/mock/MockPythLazer.sol
@@ -2,4 +2,24 @@
 
 pragma solidity ^0.8.0;
 
-contract MockPythLazer {}
+contract MockPythLazer {
+    uint256 public verification_fee = 0;
+
+    function verifyUpdate(
+        bytes calldata update
+    ) public payable returns (bytes calldata payload, address signer) {
+        if (update.length < 71) {
+            revert("input too short");
+        }
+        uint16 payload_len = uint16(bytes2(update[69:71]));
+        if (update.length < 71 + payload_len) {
+            revert("input too short");
+        }
+        payload = update[71:71 + payload_len];
+        signer = address(0);
+    }
+
+    function isValidSigner(address) external pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -622,30 +622,14 @@ library DecreasePositionCollateralUtils {
             fees
         );
 
-        if (BaseOrderUtils.isLiquidationOrder(params.order.orderType())) {
-            // specific event for insolvent liquidations so off-chain keepers / indexers
-            // can track bad debt socialized to the pool separately from other insolvent closes.
-            PositionEventUtils.emitInsolventLiquidation(
-                params.contracts.eventEmitter,
-                params.orderKey,
-                params.positionKey,
-                params.market.marketToken,
-                params.position.collateralToken(),
-                params.position.collateralAmount(),
-                values.basePnlUsd,
-                collateralCache.result.remainingCostUsd,
-                step
-            );
-        } else {
-            PositionEventUtils.emitInsolventClose(
-                params.contracts.eventEmitter,
-                params.orderKey,
-                params.position.collateralAmount(),
-                values.basePnlUsd,
-                collateralCache.result.remainingCostUsd,
-                step
-            );
-        }
+        PositionEventUtils.emitInsolventClose(
+            params.contracts.eventEmitter,
+            params.orderKey,
+            params.position.collateralAmount(),
+            values.basePnlUsd,
+            collateralCache.result.remainingCostUsd,
+            step
+        );
 
         return (values, getEmptyFees(fees));
     }

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -622,14 +622,30 @@ library DecreasePositionCollateralUtils {
             fees
         );
 
-        PositionEventUtils.emitInsolventClose(
-            params.contracts.eventEmitter,
-            params.orderKey,
-            params.position.collateralAmount(),
-            values.basePnlUsd,
-            collateralCache.result.remainingCostUsd,
-            step
-        );
+        if (BaseOrderUtils.isLiquidationOrder(params.order.orderType())) {
+            // specific event for insolvent liquidations so off-chain keepers / indexers
+            // can track bad debt socialized to the pool separately from other insolvent closes.
+            PositionEventUtils.emitInsolventLiquidation(
+                params.contracts.eventEmitter,
+                params.orderKey,
+                params.positionKey,
+                params.market.marketToken,
+                params.position.collateralToken(),
+                params.position.collateralAmount(),
+                values.basePnlUsd,
+                collateralCache.result.remainingCostUsd,
+                step
+            );
+        } else {
+            PositionEventUtils.emitInsolventClose(
+                params.contracts.eventEmitter,
+                params.orderKey,
+                params.position.collateralAmount(),
+                values.basePnlUsd,
+                collateralCache.result.remainingCostUsd,
+                step
+            );
+        }
 
         return (values, getEmptyFees(fees));
     }

--- a/contracts/position/DecreasePositionUtils.sol
+++ b/contracts/position/DecreasePositionUtils.sol
@@ -224,7 +224,8 @@ library DecreasePositionUtils {
                     reason,
                     info.remainingCollateralUsd,
                     info.minCollateralUsd,
-                    info.minCollateralUsdForLeverage
+                    info.requiredCollateralUsd,
+                    info.mmr
                 );
             }
         }

--- a/contracts/position/PositionEventUtils.sol
+++ b/contracts/position/PositionEventUtils.sol
@@ -169,6 +169,45 @@ library PositionEventUtils {
         );
     }
 
+    // @dev emitted when a liquidation order closes a position that could not pay all costs
+    // from collateral. remainingCostUsd is the bad debt socialized to the pool.
+    function emitInsolventLiquidation(
+        EventEmitter eventEmitter,
+        bytes32 orderKey,
+        bytes32 positionKey,
+        address market,
+        address collateralToken,
+        uint256 positionCollateralAmount,
+        int256 basePnlUsd,
+        uint256 remainingCostUsd,
+        string memory step
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "collateralToken", collateralToken);
+
+        eventData.bytes32Items.initItems(2);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+        eventData.bytes32Items.setItem(1, "positionKey", positionKey);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "positionCollateralAmount", positionCollateralAmount);
+        eventData.uintItems.setItem(1, "remainingCostUsd", remainingCostUsd);
+
+        eventData.intItems.initItems(1);
+        eventData.intItems.setItem(0, "basePnlUsd", basePnlUsd);
+
+        eventData.stringItems.initItems(1);
+        eventData.stringItems.setItem(0, "step", step);
+
+        eventEmitter.emitEventLog(
+            "InsolventLiquidation",
+            eventData
+        );
+    }
+
     function emitInsufficientFundingFeePayment(
         EventEmitter eventEmitter,
         address market,

--- a/contracts/position/PositionEventUtils.sol
+++ b/contracts/position/PositionEventUtils.sol
@@ -169,45 +169,6 @@ library PositionEventUtils {
         );
     }
 
-    // @dev emitted when a liquidation order closes a position that could not pay all costs
-    // from collateral. remainingCostUsd is the bad debt socialized to the pool.
-    function emitInsolventLiquidation(
-        EventEmitter eventEmitter,
-        bytes32 orderKey,
-        bytes32 positionKey,
-        address market,
-        address collateralToken,
-        uint256 positionCollateralAmount,
-        int256 basePnlUsd,
-        uint256 remainingCostUsd,
-        string memory step
-    ) external {
-        EventUtils.EventLogData memory eventData;
-
-        eventData.addressItems.initItems(2);
-        eventData.addressItems.setItem(0, "market", market);
-        eventData.addressItems.setItem(1, "collateralToken", collateralToken);
-
-        eventData.bytes32Items.initItems(2);
-        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
-        eventData.bytes32Items.setItem(1, "positionKey", positionKey);
-
-        eventData.uintItems.initItems(2);
-        eventData.uintItems.setItem(0, "positionCollateralAmount", positionCollateralAmount);
-        eventData.uintItems.setItem(1, "remainingCostUsd", remainingCostUsd);
-
-        eventData.intItems.initItems(1);
-        eventData.intItems.setItem(0, "basePnlUsd", basePnlUsd);
-
-        eventData.stringItems.initItems(1);
-        eventData.stringItems.setItem(0, "step", step);
-
-        eventEmitter.emitEventLog(
-            "InsolventLiquidation",
-            eventData
-        );
-    }
-
     function emitInsufficientFundingFeePayment(
         EventEmitter eventEmitter,
         address market,

--- a/contracts/position/PositionUtils.sol
+++ b/contracts/position/PositionUtils.sol
@@ -129,20 +129,21 @@ library PositionUtils {
     struct IsPositionLiquidatableInfo {
         int256 remainingCollateralUsd;
         int256 minCollateralUsd;
-        int256 minCollateralUsdForLeverage;
+        int256 requiredCollateralUsd;
+        uint256 mmr;
     }
 
     // @dev IsPositionLiquidatableCache struct used in isPositionLiquidatable
     // to avoid stack too deep errors
     // @param positionPnlUsd the position's pnl in USD
-    // @param minCollateralFactor the min collateral factor
+    // @param mmr the dynamic maintenance margin ratio for the position
     // @param collateralTokenPrice the collateral token price
     // @param collateralUsd the position's collateral in USD
     // @param usdDeltaForPriceImpact the usdDelta value for the price impact calculation
     // @param priceImpactUsd the price impact of closing the position in USD
     struct IsPositionLiquidatableCache {
         int256 positionPnlUsd;
-        uint256 minCollateralFactor;
+        uint256 mmr;
         Price.Props collateralTokenPrice;
         uint256 collateralUsd;
         int256 usdDeltaForPriceImpact;
@@ -280,6 +281,23 @@ library PositionUtils {
             }
         }
 
+        // enforce min_leverage lower bound when configured (> 0 is opt-in)
+        uint256 minLeverage = MarketUtils.getMinLeverage(dataStore, market.marketToken);
+        if (minLeverage > 0) {
+            Price.Props memory collateralTokenPrice = MarketUtils.getCachedTokenPrice(
+                position.collateralToken(),
+                market,
+                prices
+            );
+            uint256 collateralUsd = position.collateralAmount() * collateralTokenPrice.min;
+            if (collateralUsd > 0) {
+                uint256 currLeverage = Precision.toFactor(position.sizeInUsd(), collateralUsd);
+                if (currLeverage < minLeverage) {
+                    revert Errors.InvalidLeverage(currLeverage, minLeverage);
+                }
+            }
+        }
+
         (bool isLiquidatable, string memory reason, IsPositionLiquidatableInfo memory info) = isPositionLiquidatable(
             dataStore,
             referralStorage,
@@ -294,7 +312,8 @@ library PositionUtils {
                 reason,
                 info.remainingCollateralUsd,
                 info.minCollateralUsd,
-                info.minCollateralUsdForLeverage
+                info.requiredCollateralUsd,
+                info.mmr
             );
         }
     }
@@ -400,13 +419,7 @@ library PositionUtils {
             + cache.priceImpactUsd
             - collateralCostUsd.toInt256();
 
-        cache.minCollateralFactor = MarketUtils.getMinMaintainCollateralFactor(dataStore, market.marketToken);
-
-        // validate if (remaining collateral) / position.size is less than the min collateral factor (max leverage exceeded)
-        // this validation includes the position fee to be paid when closing the position
-        // i.e. if the position does not have sufficient collateral after closing fees it is considered a liquidatable position
-        info.minCollateralUsdForLeverage = Precision.applyFactor(position.sizeInUsd(), cache.minCollateralFactor).toInt256();
-
+        // absolute USD floor on remaining collateral (independent of leverage)
         if (shouldValidateMinCollateralUsd) {
             info.minCollateralUsd = dataStore.getUint(Keys.MIN_COLLATERAL_USD).toInt256();
             if (info.remainingCollateralUsd < info.minCollateralUsd) {
@@ -414,12 +427,24 @@ library PositionUtils {
             }
         }
 
+        // insolvent — liquidatable regardless of MMR
         if (info.remainingCollateralUsd <= 0) {
-            return (true, "< 0", info);
+            return (true, "insolvent", info);
         }
 
-        if (info.remainingCollateralUsd < info.minCollateralUsdForLeverage) {
-            return (true, "min collateral for leverage", info);
+        // MMR is computed from leverage at last modification (sizeInUsd / collateralUsd),
+        // not from the current mark price. Stable between user-initiated modifications.
+        cache.mmr = MarketUtils.getDynamicMmr(
+            dataStore,
+            market.marketToken,
+            position.sizeInUsd(),
+            cache.collateralUsd
+        );
+        info.mmr = cache.mmr;
+        info.requiredCollateralUsd = Precision.applyFactor(position.sizeInUsd(), cache.mmr).toInt256();
+
+        if (info.remainingCollateralUsd < info.requiredCollateralUsd) {
+            return (true, "mmr breach", info);
         }
 
         return (false, "", info);
@@ -471,26 +496,32 @@ library PositionUtils {
             return (false, remainingCollateralUsd);
         }
 
-        // the min collateral factor will increase as the open interest for a market increases
-        // this may lead to previously created limit increase orders not being executable
-        //
-        // the position's pnl is not factored into the remainingCollateralUsd value, since
-        // factoring in a positive pnl may allow the user to manipulate price and bypass this check
-        // it may be useful to factor in a negative pnl for this check, this can be added if required
-        uint256 minCollateralFactor = MarketUtils.getMinCollateralFactorForOpenInterest(
+        // the open-interest-based floor grows as OI expands; kept to discourage concentration.
+        // the position's pnl is not factored into remainingCollateralUsd, since factoring in a
+        // positive pnl may allow the user to manipulate price and bypass this check.
+        uint256 openInterestMinCollateralFactor = MarketUtils.getMinCollateralFactorForOpenInterest(
             dataStore,
             market,
             values.openInterestDelta,
             isLong
         );
 
-        uint256 minCollateralFactorForMarket = MarketUtils.getMinCollateralFactor(dataStore, market.marketToken);
-        // use the minCollateralFactor for the market if it is larger
-        if (minCollateralFactorForMarket > minCollateralFactor) {
-            minCollateralFactor = minCollateralFactorForMarket;
-        }
+        int256 minCollateralUsdForOpenInterest = Precision.applyFactor(values.positionSizeInUsd, openInterestMinCollateralFactor).toInt256();
 
-        int256 minCollateralUsdForLeverage = Precision.applyFactor(values.positionSizeInUsd, minCollateralFactor).toInt256();
+        // max_leverage-derived floor: required collateral >= sizeInUsd / max_leverage.
+        // If max_leverage is unset (0), the position cannot be validated — reject to avoid
+        // accidentally opening with no leverage cap.
+        uint256 maxLeverage = MarketUtils.getMaxLeverage(dataStore, market.marketToken);
+        if (maxLeverage == 0) {
+            return (false, remainingCollateralUsd);
+        }
+        int256 minCollateralUsdForMaxLeverage = Precision.toFactor(values.positionSizeInUsd, maxLeverage).toInt256();
+
+        // take the tighter of the two floors
+        int256 minCollateralUsdForLeverage = minCollateralUsdForMaxLeverage > minCollateralUsdForOpenInterest
+            ? minCollateralUsdForMaxLeverage
+            : minCollateralUsdForOpenInterest;
+
         bool willBeSufficient = remainingCollateralUsd >= minCollateralUsdForLeverage;
 
         return (willBeSufficient, remainingCollateralUsd);

--- a/contracts/test/MarketUtilsTest.sol
+++ b/contracts/test/MarketUtilsTest.sol
@@ -33,4 +33,13 @@ contract MarketUtilsTest {
     ) public view returns (uint256) {
         return MarketUtils.getReservedUsd(dataStore, market, prices, isLong);
     }
+
+    function getDynamicMmr(
+        DataStore dataStore,
+        address market,
+        uint256 sizeInUsd,
+        uint256 collateralUsd
+    ) public view returns (uint256) {
+        return MarketUtils.getDynamicMmr(dataStore, market, sizeInUsd, collateralUsd);
+    }
 }

--- a/deploy/configureGovTimelockController.ts
+++ b/deploy/configureGovTimelockController.ts
@@ -19,4 +19,6 @@ const func = async ({ getNamedAccounts }) => {
 func.dependencies = ["GovTimelockController", "ProtocolGovernor"];
 func.tags = ["ConfigureGovTimelockController"];
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/configureOracleTokens.ts
+++ b/deploy/configureOracleTokens.ts
@@ -8,10 +8,12 @@ const func = async ({ gmx, deployments, network }: HardhatRuntimeEnvironment) =>
   const { get } = deployments;
 
   const defaultOracleProvider = network.name === "hardhat" ? "gmOracle" : "pythLazerFeed";
-  const oracleProviders = {
-    gmOracle: (await get("GmOracleProvider")).address,
+  const oracleProviders: Record<string, string> = {
     pythLazerFeed: (await get("PythLazerFeedProvider")).address,
   };
+  if (network.name === "hardhat") {
+    oracleProviders.gmOracle = (await get("GmOracleProvider")).address;
+  }
 
   for (const tokenSymbol of Object.keys(tokens)) {
     const token = tokens[tokenSymbol];
@@ -55,7 +57,7 @@ const func = async ({ gmx, deployments, network }: HardhatRuntimeEnvironment) =>
   }
 };
 
-func.dependencies = ["Tokens", "PriceFeeds", "DataStore", "GmOracleProvider", "PythLazerFeedProvider"];
+func.dependencies = ["Tokens", "PriceFeeds", "DataStore", "PythLazerFeedProvider"];
 func.tags = ["ConfigureOracleTokens"];
 
 export default func;

--- a/deploy/deployAdlHandler.ts
+++ b/deploy/deployAdlHandler.ts
@@ -31,8 +31,10 @@ const func = createDeployFunction({
   },
 });
 
-func.skip = async () => {
-  return process.env.SKIP_HANDLER_DEPLOYMENTS ? true : false;
+func.skip = async (hre: any) => {
+  if (process.env.SKIP_HANDLER_DEPLOYMENTS) return true;
+  if (hre.network.name === "localhost") return true;
+  return false;
 };
 
 export default func;

--- a/deploy/deployAndConfigureAssetTokens.ts
+++ b/deploy/deployAndConfigureAssetTokens.ts
@@ -15,7 +15,9 @@ const func = async ({ deployments, getNamedAccounts }: HardhatRuntimeEnvironment
     ["British Pound", "GBP"],
     ["Euro", "EUR"],
     ["Gold", "GOLD"],
+    ["Silver", "XAG"],
     ["Japaness Yen", "JPY"],
+    ["West Texas Intermediate", "WTI"],
   ]) {
     const nonce = await ethers.provider.getTransactionCount(deployer, "pending");
     const deployment = await deploy(name, {

--- a/deploy/deployAndConfigureAssetTokens.ts
+++ b/deploy/deployAndConfigureAssetTokens.ts
@@ -33,4 +33,6 @@ const func = async ({ deployments, getNamedAccounts }: HardhatRuntimeEnvironment
 func.tags = ["Assets"];
 func.dependencies = ["DataStore", "RoleStore"];
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployAutoCancelConfig.ts
+++ b/deploy/deployAutoCancelConfig.ts
@@ -15,4 +15,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployChainlinkDataStreamProvider.ts
+++ b/deploy/deployChainlinkDataStreamProvider.ts
@@ -11,7 +11,7 @@ const func = createDeployFunction({
   getDeployArgs: async ({ dependencyContracts, gmx, network, get }) => {
     const oracleConfig = await gmx.getOracle();
     let dataStreamFeedVerifierAddress = oracleConfig.dataStreamFeedVerifier;
-    if (network.name === "hardhat") {
+    if (network.name === "hardhat" || network.name === "localhost") {
       const dataStreamFeedVerifier = await get("MockDataStreamVerifier");
       dataStreamFeedVerifierAddress = dataStreamFeedVerifier.address;
     }
@@ -35,7 +35,7 @@ const func = createDeployFunction({
 func.dependencies = func.dependencies.concat(["MockDataStreamVerifier"]);
 
 func.skip = async ({ network }: HardhatRuntimeEnvironment) => {
-  return network.name === "base" || network.name === "baseSepolia";
+  return network.name === "base" || network.name === "baseSepolia" || network.name === "localhost";
 };
 
 export default func;

--- a/deploy/deployConfigSyncer.ts
+++ b/deploy/deployConfigSyncer.ts
@@ -10,7 +10,7 @@ const func = createDeployFunction({
   getDeployArgs: async ({ dependencyContracts, gmx, network, get }) => {
     const riskOracleConfig = await gmx.getRiskOracle();
     let riskOracleAddress = riskOracleConfig.riskOracle;
-    if (network.name === "hardhat") {
+    if (network.name === "hardhat" || network.name === "localhost") {
       const riskOracle = await get("MockRiskOracle");
       riskOracleAddress = riskOracle.address;
     }
@@ -30,7 +30,7 @@ const func = createDeployFunction({
 func.dependencies = func.dependencies.concat(["MockRiskOracle"]);
 
 func.skip = async ({ network }: HardhatRuntimeEnvironment) => {
-  return network.name === "base" || network.name === "baseSepolia";
+  return network.name === "base" || network.name === "baseSepolia" || network.name === "localhost";
 };
 
 export default func;

--- a/deploy/deployFeeHandler.ts
+++ b/deploy/deployFeeHandler.ts
@@ -39,7 +39,7 @@ const func = createDeployFunction({
 
 func.dependencies = func.dependencies.concat(["MockVaultV1"]);
 func.skip = async (hre: HardhatRuntimeEnvironment) => {
-  if (hre.network.name === "avalancheFuji") {
+  if (hre.network.name === "avalancheFuji" || hre.network.name === "localhost") {
     return true;
   }
 

--- a/deploy/deployGelatoRelayRouter.ts
+++ b/deploy/deployGelatoRelayRouter.ts
@@ -24,4 +24,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvDepositEventUtils.ts
+++ b/deploy/deployGlvDepositEventUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvDepositEventUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvDepositStoreUtils.ts
+++ b/deploy/deployGlvDepositStoreUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvDepositStoreUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvDepositUtils.ts
+++ b/deploy/deployGlvDepositUtils.ts
@@ -14,4 +14,6 @@ const func = createDeployFunction({
   ],
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvFactory.ts
+++ b/deploy/deployGlvFactory.ts
@@ -16,4 +16,6 @@ const func = createDeployFunction({
   id: "GlvFactory_2",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvHandler.ts
+++ b/deploy/deployGlvHandler.ts
@@ -23,8 +23,10 @@ const func = createDeployFunction({
   },
 });
 
-func.skip = async () => {
-  return process.env.SKIP_HANDLER_DEPLOYMENTS ? true : false;
+func.skip = async (hre: any) => {
+  if (process.env.SKIP_HANDLER_DEPLOYMENTS) return true;
+  if (hre.network.name === "localhost") return true;
+  return false;
 };
 
 export default func;

--- a/deploy/deployGlvReader.ts
+++ b/deploy/deployGlvReader.ts
@@ -13,4 +13,6 @@ const func = createDeployFunction({
   ],
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvRouter.ts
+++ b/deploy/deployGlvRouter.ts
@@ -16,4 +16,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvShiftEventUtils.ts
+++ b/deploy/deployGlvShiftEventUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvShiftEventUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvShiftStoreUtils.ts
+++ b/deploy/deployGlvShiftStoreUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvShiftStoreUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvShiftUtils.ts
+++ b/deploy/deployGlvShiftUtils.ts
@@ -14,4 +14,6 @@ const func = createDeployFunction({
   ],
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvStoreUtils.ts
+++ b/deploy/deployGlvStoreUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvStoreUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvUtils.ts
+++ b/deploy/deployGlvUtils.ts
@@ -5,4 +5,6 @@ const func = createDeployFunction({
   libraryNames: ["MarketUtils", "MarketStoreUtils", "GlvStoreUtils"],
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvVault.ts
+++ b/deploy/deployGlvVault.ts
@@ -11,4 +11,6 @@ const func = createDeployFunction({
   id: "GlvVault_1",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvWithdrawalEventUtils.ts
+++ b/deploy/deployGlvWithdrawalEventUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvWithdrawalEventUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvWithdrawalStoreUtils.ts
+++ b/deploy/deployGlvWithdrawalStoreUtils.ts
@@ -4,4 +4,6 @@ const func = createDeployFunction({
   contractName: "GlvWithdrawalStoreUtils",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGlvWithdrawalUtils.ts
+++ b/deploy/deployGlvWithdrawalUtils.ts
@@ -14,4 +14,6 @@ const func = createDeployFunction({
   ],
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGmOracleProvider.ts
+++ b/deploy/deployGmOracleProvider.ts
@@ -20,4 +20,6 @@ const func = createDeployFunction({
   id: "GmOracleProvider_2",
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGovTimelockController.ts
+++ b/deploy/deployGovTimelockController.ts
@@ -15,4 +15,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployGovToken.ts
+++ b/deploy/deployGovToken.ts
@@ -14,4 +14,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployLiquidationHandler.ts
+++ b/deploy/deployLiquidationHandler.ts
@@ -30,8 +30,10 @@ const func = createDeployFunction({
   },
 });
 
-func.skip = async () => {
-  return process.env.SKIP_HANDLER_DEPLOYMENTS ? true : false;
+func.skip = async (hre: any) => {
+  if (process.env.SKIP_HANDLER_DEPLOYMENTS) return true;
+  if (hre.network.name === "localhost") return true;
+  return false;
 };
 
 export default func;

--- a/deploy/deployMockPythLazer.ts
+++ b/deploy/deployMockPythLazer.ts
@@ -6,7 +6,7 @@ const func = createDeployFunction({
 });
 
 func.skip = async ({ network }: HardhatRuntimeEnvironment) => {
-  const shouldDeployForNetwork = ["hardhat"];
+  const shouldDeployForNetwork = ["hardhat", "localhost"];
   return !shouldDeployForNetwork.includes(network.name);
 };
 

--- a/deploy/deployOracle.ts
+++ b/deploy/deployOracle.ts
@@ -46,6 +46,6 @@ const func = createDeployFunction({
   id: "Oracle_5",
 });
 
-func.dependencies = func.dependencies.concat(["Tokens", "MockDataStreamVerifier", "ChainlinkPriceFeedProvider"]);
+func.dependencies = func.dependencies.concat(["Tokens", "ChainlinkPriceFeedProvider"]);
 
 export default func;

--- a/deploy/deployProtocolGovernor.ts
+++ b/deploy/deployProtocolGovernor.ts
@@ -19,4 +19,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployPythLazerFeedProvider.ts
+++ b/deploy/deployPythLazerFeedProvider.ts
@@ -11,7 +11,7 @@ const func = createDeployFunction({
   getDeployArgs: async ({ dependencyContracts, get, gmx, network }) => {
     const oracleConfig = await gmx.getOracle();
     let pythLazerFeedVerifierAddress = oracleConfig.pythLazerFeedVerifier;
-    if (network.name === "hardhat") {
+    if (network.name === "hardhat" || network.name === "localhost") {
       const pythLazerFeedVerifier = await get("MockPythLazer");
       pythLazerFeedVerifierAddress = pythLazerFeedVerifier.address;
     }

--- a/deploy/deployReferralStorage.ts
+++ b/deploy/deployReferralStorage.ts
@@ -32,7 +32,7 @@ const func = createDeployFunction({
 });
 
 func.skip = async ({ network }: HardhatRuntimeEnvironment) => {
-  const shouldDeployForNetwork = ["avalancheFuji", "arbitrumSepolia", "base", "baseSepolia", "hardhat"];
+  const shouldDeployForNetwork = ["avalancheFuji", "arbitrumSepolia", "base", "baseSepolia", "hardhat", "localhost"];
   return !shouldDeployForNetwork.includes(network.name);
 };
 

--- a/deploy/deploySubaccountGelatoRelayRouter.ts
+++ b/deploy/deploySubaccountGelatoRelayRouter.ts
@@ -24,4 +24,6 @@ const func = createDeployFunction({
   },
 });
 
+func.skip = async ({ network }: any) => network.name === "localhost";
+
 export default func;

--- a/deploy/deployTestTokens.ts
+++ b/deploy/deployTestTokens.ts
@@ -38,7 +38,7 @@ const func = async ({ getNamedAccounts, deployments, gmx, network }: HardhatRunt
 
     tokens[tokenSymbol].address = address;
     if (newlyDeployed) {
-      if (token.wrappedNative && !network.live) {
+      if (token.wrappedNative && !network.live && network.name === "hardhat") {
         await setBalance(address, expandDecimals(1000, token.decimals));
       }
 

--- a/deploy/fundAccounts.ts
+++ b/deploy/fundAccounts.ts
@@ -11,7 +11,7 @@ const func = async ({ getNamedAccounts, deployments }: HardhatRuntimeEnvironment
 };
 
 func.skip = async ({ network }) => {
-  return network.live;
+  return network.live || network.name !== "hardhat";
 };
 func.tags = ["FundAccounts"];
 export default func;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -246,6 +246,13 @@ const config: HardhatUserConfig = {
         },
       },
     },
+    baseSepoliaFork: {
+      url: process.env.ANVIL_RPC_URL || "http://127.0.0.1:8545",
+      chainId: 84532,
+      accounts: process.env.FORK_DEPLOYER_KEY ? [process.env.FORK_DEPLOYER_KEY] : getEnvAccounts(),
+      gas: "auto",
+      gasMultiplier: 2.0,
+    },
   },
   // hardhat-deploy has issues with some contracts
   // https://github.com/wighawag/hardhat-deploy/issues/264

--- a/scripts/deploy-liquidation-upgrade.ts
+++ b/scripts/deploy-liquidation-upgrade.ts
@@ -1,0 +1,105 @@
+import hre from "hardhat";
+import { hashString } from "../utils/hash";
+
+async function main() {
+  const { deployments, getNamedAccounts, ethers } = hre;
+  const { deploy, get } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  console.log(`[liq-upgrade] deployer=${deployer} network=${hre.network.name}`);
+
+  const libAddrs = async (names: string[]) => {
+    const m: Record<string, string> = {};
+    for (const n of names) m[n] = (await get(n)).address;
+    return m;
+  };
+
+  const deployLib = async (name: string, libraryNames: string[] = []) => {
+    const libraries = libraryNames.length ? await libAddrs(libraryNames) : undefined;
+    const d = await deploy(name, { from: deployer, log: true, libraries });
+    console.log(`[liq-upgrade] ${name} -> ${d.address}`);
+    return d.address;
+  };
+
+  await deployLib("PositionEventUtils");
+  await deployLib("MarketUtils", ["MarketEventUtils", "MarketStoreUtils"]);
+  await deployLib("PositionUtils", ["MarketStoreUtils", "MarketUtils", "PositionPricingUtils"]);
+  await deployLib("DecreasePositionCollateralUtils", [
+    "BaseOrderUtils",
+    "FeeUtils",
+    "MarketCollateralUtils",
+    "MarketEventUtils",
+    "PositionUtils",
+    "PositionPricingUtils",
+    "PositionEventUtils",
+    "OrderEventUtils",
+    "DecreasePositionSwapUtils",
+  ]);
+  await deployLib("DecreasePositionUtils", [
+    "MarketCollateralUtils",
+    "MarketUtils",
+    "MarketEventUtils",
+    "PositionUtils",
+    "PositionStoreUtils",
+    "PositionEventUtils",
+    "OrderEventUtils",
+    "PositionPricingUtils",
+    "ReferralEventUtils",
+    "DecreasePositionCollateralUtils",
+    "DecreasePositionSwapUtils",
+  ]);
+  await deployLib("LiquidationUtils", ["PositionStoreUtils", "OrderStoreUtils", "OrderEventUtils"]);
+
+  const envAddr = (k: string): string => {
+    const v = process.env[k];
+    if (!v || !v.startsWith("0x") || v.length !== 42) {
+      throw new Error(`[liq-upgrade] ${k} env var missing/invalid: ${v}`);
+    }
+    return v;
+  };
+  const args = [
+    envAddr("OXM_ROLE_STORE"),
+    envAddr("OXM_DATA_STORE"),
+    envAddr("OXM_EVENT_EMITTER"),
+    envAddr("OXM_ORACLE"),
+    envAddr("OXM_ORDER_VAULT"),
+    envAddr("OXM_SWAP_HANDLER"),
+    envAddr("OXM_REFERRAL_STORAGE"),
+  ];
+
+  const lhLibs = await libAddrs([
+    "OrderUtils",
+    "ExecuteOrderUtils",
+    "LiquidationUtils",
+    "MarketStoreUtils",
+    "PositionStoreUtils",
+    "OrderStoreUtils",
+  ]);
+  const lh = await deploy("LiquidationHandler", {
+    from: deployer,
+    log: true,
+    args,
+    libraries: lhLibs,
+  });
+  console.log(`[liq-upgrade] LiquidationHandler -> ${lh.address}`);
+
+  const roleStore = await ethers.getContractAt(
+    ["function grantRole(address,bytes32)", "function hasRole(address,bytes32) view returns (bool)"],
+    envAddr("OXM_ROLE_STORE")
+  );
+  const controllerHash = hashString("CONTROLLER");
+  const hasRole = await roleStore.hasRole(lh.address, controllerHash);
+  if (!hasRole) {
+    const signer = await ethers.getSigner(deployer);
+    const tx = await roleStore.connect(signer).grantRole(lh.address, controllerHash);
+    await tx.wait();
+    console.log(`[liq-upgrade] granted CONTROLLER to ${lh.address}`);
+  } else {
+    console.log(`[liq-upgrade] CONTROLLER already granted to ${lh.address}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/deploy-silver-market-v2.ts
+++ b/scripts/deploy-silver-market-v2.ts
@@ -32,16 +32,17 @@ const XAG_TOKEN = "0x25f79151C3E00ba7710EcF02192836994E36b440";
 // MCF of 3.333e27 in 1e30 precision = 0.003333 = 1/300x
 // Actually 3333e24 / 1e30 = 0.003333 → 1/0.003333 = 300x
 // GOLD docs say 200x but MCF gives 300x. Using the actual on-chain value.
-const MCF = ethers.BigNumber.from("3333000000000000000000000000"); // 3.333e27 — matches GOLD
-
 const MARKET_CONFIG = {
   // Pool limits
   MAX_POOL_AMOUNT_USD0: ethers.BigNumber.from("100000000000000"), // 1e14 (100M USD0)
   MAX_POOL_AMOUNT_INDEX: ethers.BigNumber.from(0), // index token not used as collateral
 
-  // Leverage & collateral
-  MIN_COLLATERAL_FACTOR: MCF,
-  MIN_MAINTAIN_COLLATERAL_FACTOR: MCF,
+  // Dynamic MMR (commodity defaults — 200x max leverage with 50% buffer at the cap)
+  MAX_LEVERAGE: ethers.BigNumber.from("200000000000000000000000000000000"), // 200 in FLOAT_PRECISION
+  MIN_LEVERAGE: ethers.BigNumber.from(0), // opt-in
+  MIN_MMR: ethers.BigNumber.from("2000000000000000000000000000"), // 0.2% = 2e27
+  MAX_MMR: ethers.BigNumber.from("100000000000000000000000000000"), // 10% = 1e29
+  MMR_TUNING: ethers.BigNumber.from("2500000000000000000000000000"), // 0.25% = 2.5e27 (0.5 / 200x)
 
   // Reserve factors
   RESERVE_FACTOR: ethers.BigNumber.from("950000000000000000000000000000"), // 9.5e29
@@ -173,22 +174,19 @@ async function main() {
   );
   console.log("  MAX_POOL_AMOUNT (USD0): 1e14");
 
-  // Leverage
+  // Dynamic MMR (leverage band + MMR curve)
   calls.push(
-    config.interface.encodeFunctionData("setUint", [
-      keys.MIN_COLLATERAL_FACTOR,
-      marketKeyData,
-      MARKET_CONFIG.MIN_COLLATERAL_FACTOR,
-    ])
+    config.interface.encodeFunctionData("setUint", [keys.MAX_LEVERAGE, marketKeyData, MARKET_CONFIG.MAX_LEVERAGE])
   );
   calls.push(
-    config.interface.encodeFunctionData("setUint", [
-      keys.MIN_MAINTAIN_COLLATERAL_FACTOR,
-      marketKeyData,
-      MARKET_CONFIG.MIN_MAINTAIN_COLLATERAL_FACTOR,
-    ])
+    config.interface.encodeFunctionData("setUint", [keys.MIN_LEVERAGE, marketKeyData, MARKET_CONFIG.MIN_LEVERAGE])
   );
-  console.log("  MIN_COLLATERAL_FACTOR: 3.333e27 (200x)");
+  calls.push(config.interface.encodeFunctionData("setUint", [keys.MIN_MMR, marketKeyData, MARKET_CONFIG.MIN_MMR]));
+  calls.push(config.interface.encodeFunctionData("setUint", [keys.MAX_MMR, marketKeyData, MARKET_CONFIG.MAX_MMR]));
+  calls.push(
+    config.interface.encodeFunctionData("setUint", [keys.MMR_TUNING, marketKeyData, MARKET_CONFIG.MMR_TUNING])
+  );
+  console.log("  Dynamic MMR: max_leverage=200x, min_mmr=0.2%, max_mmr=10%, tuning=0.25% (50% buffer at cap)");
 
   // Reserve factors
   calls.push(

--- a/scripts/deploy-silver-v3.ts
+++ b/scripts/deploy-silver-v3.ts
@@ -23,7 +23,12 @@ const MARKET_TYPE = hashString("silver-v2"); // different from old market's byte
 const CFG = {
   MAX_POOL_AMOUNT: ethers.BigNumber.from("100000000000000"), // 1e14
   MAX_POOL_USD_FOR_DEPOSIT: ethers.BigNumber.from("100000000000000000000000000000000000000"), // 1e38
-  MCF: ethers.BigNumber.from("3333000000000000000000000000"), // 3.333e27 → 200x
+  // Dynamic MMR (commodity defaults — 200x max leverage, 50% collateral buffer at the cap)
+  MAX_LEVERAGE: ethers.BigNumber.from("200000000000000000000000000000000"), // 200 in FLOAT_PRECISION
+  MIN_LEVERAGE: ethers.BigNumber.from(0), // opt-in
+  MIN_MMR: ethers.BigNumber.from("2000000000000000000000000000"), // 0.2% = 2e27
+  MAX_MMR: ethers.BigNumber.from("100000000000000000000000000000"), // 10% = 1e29
+  MMR_TUNING: ethers.BigNumber.from("2500000000000000000000000000"), // 0.25% = 2.5e27 (0.5 / 200x)
   RESERVE_FACTOR: ethers.BigNumber.from("950000000000000000000000000000"), // 9.5e29
   OI_RESERVE: ethers.BigNumber.from("900000000000000000000000000000"), // 9e29
   MAX_OI: ethers.BigNumber.from("1000000000000000000000000000000000000000"), // 1e39
@@ -108,18 +113,19 @@ async function main() {
   );
   console.log("  Pool limits: MAX_POOL=1e14, MAX_USD_DEPOSIT=1e38");
 
-  // Leverage (keyed by market)
+  // Dynamic MMR (leverage band + MMR curve, keyed by market)
   calls.push(
-    config.interface.encodeFunctionData("setUint", [keys.MIN_COLLATERAL_FACTOR, encodeData(["address"], [m]), CFG.MCF])
+    config.interface.encodeFunctionData("setUint", [keys.MAX_LEVERAGE, encodeData(["address"], [m]), CFG.MAX_LEVERAGE])
   );
   calls.push(
-    config.interface.encodeFunctionData("setUint", [
-      keys.MIN_MAINTAIN_COLLATERAL_FACTOR,
-      encodeData(["address"], [m]),
-      CFG.MCF,
-    ])
+    config.interface.encodeFunctionData("setUint", [keys.MIN_LEVERAGE, encodeData(["address"], [m]), CFG.MIN_LEVERAGE])
   );
-  console.log("  Leverage: 200x (MCF=3.333e27)");
+  calls.push(config.interface.encodeFunctionData("setUint", [keys.MIN_MMR, encodeData(["address"], [m]), CFG.MIN_MMR]));
+  calls.push(config.interface.encodeFunctionData("setUint", [keys.MAX_MMR, encodeData(["address"], [m]), CFG.MAX_MMR]));
+  calls.push(
+    config.interface.encodeFunctionData("setUint", [keys.MMR_TUNING, encodeData(["address"], [m]), CFG.MMR_TUNING])
+  );
+  console.log("  Dynamic MMR: max_leverage=200x, min_mmr=0.2%, max_mmr=10%, tuning=0.25% (50% buffer at cap)");
 
   // Reserve factors (keyed by market + isLong)
   calls.push(

--- a/scripts/updateMarketConfigUtils.ts
+++ b/scripts/updateMarketConfigUtils.ts
@@ -734,7 +734,7 @@ export async function updateMarketConfig({
   includePositionImpact = false,
   includeMaxOpenInterest = false,
 }) {
-  if (!["arbitrumGoerli", "avalancheFuji", "baseSepolia", "hardhat"].includes(hre.network.name)) {
+  if (!["arbitrumGoerli", "avalancheFuji", "baseSepolia", "hardhat", "localhost"].includes(hre.network.name)) {
     const { errors } = await validateMarketConfigs();
     if (errors.length !== 0) {
       throw new Error("Invalid market configs");

--- a/scripts/updateMarketConfigUtils.ts
+++ b/scripts/updateMarketConfigUtils.ts
@@ -299,7 +299,7 @@ const processMarkets = async ({
       "uint",
       keys.MIN_MAINTAIN_COLLATERAL_FACTOR,
       encodeData(["address"], [marketToken]),
-      marketConfig.minMaintainCollateralFactor,
+      marketConfig.minMaintainCollateralFactor ?? marketConfig.minCollateralFactor,
       `minMaintainCollateralFactor ${marketLabel} (${marketToken})`
     );
 

--- a/scripts/updateMarketConfigUtils.ts
+++ b/scripts/updateMarketConfigUtils.ts
@@ -287,22 +287,6 @@ const processMarkets = async ({
       continue;
     }
 
-    await handleConfig(
-      "uint",
-      keys.MIN_COLLATERAL_FACTOR,
-      encodeData(["address"], [marketToken]),
-      marketConfig.minCollateralFactor,
-      `minCollateralFactor ${marketLabel} (${marketToken})`
-    );
-
-    await handleConfig(
-      "uint",
-      keys.MIN_MAINTAIN_COLLATERAL_FACTOR,
-      encodeData(["address"], [marketToken]),
-      marketConfig.minMaintainCollateralFactor ?? marketConfig.minCollateralFactor,
-      `minMaintainCollateralFactor ${marketLabel} (${marketToken})`
-    );
-
     if (marketConfig.maxLeverage !== undefined) {
       await handleConfig(
         "uint",

--- a/scripts/updateMarketConfigUtils.ts
+++ b/scripts/updateMarketConfigUtils.ts
@@ -303,6 +303,56 @@ const processMarkets = async ({
       `minMaintainCollateralFactor ${marketLabel} (${marketToken})`
     );
 
+    if (marketConfig.maxLeverage !== undefined) {
+      await handleConfig(
+        "uint",
+        keys.MAX_LEVERAGE,
+        encodeData(["address"], [marketToken]),
+        marketConfig.maxLeverage,
+        `maxLeverage ${marketLabel} (${marketToken})`
+      );
+    }
+
+    if (marketConfig.minLeverage !== undefined) {
+      await handleConfig(
+        "uint",
+        keys.MIN_LEVERAGE,
+        encodeData(["address"], [marketToken]),
+        marketConfig.minLeverage,
+        `minLeverage ${marketLabel} (${marketToken})`
+      );
+    }
+
+    if (marketConfig.minMmr !== undefined) {
+      await handleConfig(
+        "uint",
+        keys.MIN_MMR,
+        encodeData(["address"], [marketToken]),
+        marketConfig.minMmr,
+        `minMmr ${marketLabel} (${marketToken})`
+      );
+    }
+
+    if (marketConfig.maxMmr !== undefined) {
+      await handleConfig(
+        "uint",
+        keys.MAX_MMR,
+        encodeData(["address"], [marketToken]),
+        marketConfig.maxMmr,
+        `maxMmr ${marketLabel} (${marketToken})`
+      );
+    }
+
+    if (marketConfig.mmrTuning !== undefined) {
+      await handleConfig(
+        "uint",
+        keys.MMR_TUNING,
+        encodeData(["address"], [marketToken]),
+        marketConfig.mmrTuning,
+        `mmrTuning ${marketLabel} (${marketToken})`
+      );
+    }
+
     await handleConfig(
       "uint",
       keys.MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER,

--- a/test/exchange/DynamicMmr.ts
+++ b/test/exchange/DynamicMmr.ts
@@ -1,0 +1,168 @@
+import { expect } from "chai";
+
+import { deployFixture } from "../../utils/fixture";
+import { decimalToFloat, expandDecimals, percentageToFloat } from "../../utils/math";
+import { handleDeposit } from "../../utils/deposit";
+import { OrderType, handleOrder } from "../../utils/order";
+import { getPositionKey } from "../../utils/position";
+import * as keys from "../../utils/keys";
+
+describe("DynamicMmr", () => {
+  let fixture;
+  let user0;
+  let reader, referralStorage, dataStore, ethUsdMarket, wnt, usdc;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ user0 } = fixture.accounts);
+    ({ reader, referralStorage, dataStore, ethUsdMarket, wnt, usdc } = fixture.contracts);
+
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(5_000_000, 6),
+      },
+    });
+  });
+
+  describe("isPositionLiquidatable reason codes", () => {
+    it("returns 'mmr breach' when collateral is positive but below required", async () => {
+      // Force the MMR floor to 5% so that required = 5% of notional regardless of leverage.
+      // Opening at 4x leverage (10 WETH on $200k size) yields currLeverage below the
+      // mmr_tuning curve, so the floor governs.
+      await dataStore.setUint(keys.minMmrKey(ethUsdMarket.marketToken), percentageToFloat("5%"));
+
+      await handleOrder(fixture, {
+        create: {
+          market: ethUsdMarket,
+          initialCollateralToken: wnt,
+          initialCollateralDeltaAmount: expandDecimals(10, 18),
+          sizeDeltaUsd: decimalToFloat(200 * 1000),
+          acceptablePrice: expandDecimals(5001, 12),
+          orderType: OrderType.MarketIncrease,
+          isLong: true,
+        },
+        execute: {
+          tokens: [wnt.address, usdc.address],
+        },
+      });
+
+      const positionKey = getPositionKey(user0.address, ethUsdMarket.marketToken, wnt.address, true);
+
+      // At mark $4100: collateral (10 WETH) = $41k, PnL = 40 * (4100-5000) = -$36k
+      //   → remaining ≈ $5k (positive but below required $10k = 5% of $200k) → "mmr breach"
+      const pricesMmrBreach = {
+        indexTokenPrice: { min: expandDecimals(4100, 12), max: expandDecimals(4100, 12) },
+        longTokenPrice: { min: expandDecimals(4100, 12), max: expandDecimals(4100, 12) },
+        shortTokenPrice: { min: expandDecimals(1, 24), max: expandDecimals(1, 24) },
+      };
+
+      const [isLiquidatable, reason, info] = await reader.isPositionLiquidatable(
+        dataStore.address,
+        referralStorage.address,
+        positionKey,
+        ethUsdMarket,
+        pricesMmrBreach,
+        false
+      );
+
+      expect(isLiquidatable).to.eq(true);
+      expect(reason).to.eq("mmr breach");
+      expect(info.mmr).to.eq(percentageToFloat("5%"));
+      expect(info.requiredCollateralUsd).to.eq(decimalToFloat(200_000).mul(5).div(100));
+      expect(info.remainingCollateralUsd).to.be.gt(0);
+      expect(info.remainingCollateralUsd).to.be.lt(info.requiredCollateralUsd);
+    });
+
+    it("returns 'insolvent' when remaining collateral falls below zero", async () => {
+      await handleOrder(fixture, {
+        create: {
+          market: ethUsdMarket,
+          initialCollateralToken: wnt,
+          initialCollateralDeltaAmount: expandDecimals(10, 18),
+          sizeDeltaUsd: decimalToFloat(200 * 1000),
+          acceptablePrice: expandDecimals(5001, 12),
+          orderType: OrderType.MarketIncrease,
+          isLong: true,
+        },
+        execute: {
+          tokens: [wnt.address, usdc.address],
+        },
+      });
+
+      const positionKey = getPositionKey(user0.address, ethUsdMarket.marketToken, wnt.address, true);
+
+      // At $3000 the position's collateral (10 WETH = $30k) + PnL (-$80k) is deeply
+      // negative → "insolvent".
+      const pricesInsolvent = {
+        indexTokenPrice: { min: expandDecimals(3000, 12), max: expandDecimals(3000, 12) },
+        longTokenPrice: { min: expandDecimals(3000, 12), max: expandDecimals(3000, 12) },
+        shortTokenPrice: { min: expandDecimals(1, 24), max: expandDecimals(1, 24) },
+      };
+
+      const [isLiquidatable, reason, info] = await reader.isPositionLiquidatable(
+        dataStore.address,
+        referralStorage.address,
+        positionKey,
+        ethUsdMarket,
+        pricesInsolvent,
+        false
+      );
+
+      expect(isLiquidatable).to.eq(true);
+      expect(reason).to.eq("insolvent");
+      expect(info.remainingCollateralUsd).to.be.lt(0);
+    });
+  });
+
+  describe("willPositionCollateralBeSufficient (leverage band enforcement)", () => {
+    it("rejects increases above max_leverage with InsufficientCollateralUsd", async () => {
+      // Tighten max_leverage to 5x so that a 10x position fails the upper bound.
+      await dataStore.setUint(keys.maxLeverageKey(ethUsdMarket.marketToken), decimalToFloat(5));
+
+      // 10 WETH collateral ($50k at entry $5k) + $500k size → 10x leverage.
+      // Upper bound requires collateral >= sizeInUsd / 5 = $100k → fails.
+      await handleOrder(fixture, {
+        create: {
+          market: ethUsdMarket,
+          initialCollateralToken: wnt,
+          initialCollateralDeltaAmount: expandDecimals(10, 18),
+          sizeDeltaUsd: decimalToFloat(500 * 1000),
+          acceptablePrice: expandDecimals(5001, 12),
+          orderType: OrderType.MarketIncrease,
+          isLong: true,
+        },
+        execute: {
+          tokens: [wnt.address, usdc.address],
+          expectedCancellationReason: "InsufficientCollateralUsd",
+        },
+      });
+    });
+  });
+
+  describe("validatePosition (min_leverage gate)", () => {
+    it("rejects increases below min_leverage with InvalidLeverage", async () => {
+      // Require at least 10x leverage on this market.
+      await dataStore.setUint(keys.minLeverageKey(ethUsdMarket.marketToken), decimalToFloat(10));
+
+      // 10 WETH collateral ($50k at entry $5k) + $50k size → 1x leverage → below the
+      // market's 10x floor. validatePosition should revert with InvalidLeverage.
+      await handleOrder(fixture, {
+        create: {
+          market: ethUsdMarket,
+          initialCollateralToken: wnt,
+          initialCollateralDeltaAmount: expandDecimals(10, 18),
+          sizeDeltaUsd: decimalToFloat(50 * 1000),
+          acceptablePrice: expandDecimals(5001, 12),
+          orderType: OrderType.MarketIncrease,
+          isLong: true,
+        },
+        execute: {
+          tokens: [wnt.address, usdc.address],
+          expectedCancellationReason: "InvalidLeverage",
+        },
+      });
+    });
+  });
+});

--- a/test/exchange/LiquidationOrder.ts
+++ b/test/exchange/LiquidationOrder.ts
@@ -8,6 +8,7 @@ import { executeLiquidation } from "../../utils/liquidation";
 import { grantRole } from "../../utils/role";
 import { getAccountPositionCount } from "../../utils/position";
 import { errorsContract } from "../../utils/error";
+import { getEventData } from "../../utils/event";
 
 describe("Exchange.LiquidationOrder", () => {
   let fixture;
@@ -77,5 +78,57 @@ describe("Exchange.LiquidationOrder", () => {
 
     expect(await getAccountPositionCount(dataStore, user0.address)).eq(0);
     expect(await getOrderCount(dataStore)).eq(0);
+  });
+
+  it("emits InsolventLiquidation when collateral cannot cover fees + PnL", async () => {
+    // Open a position: 10 WETH collateral ($50k at $5k/ETH), $200k size (4x leverage).
+    // sizeInTokens = 200k / 5k = 40 ETH.
+    await handleOrder(fixture, {
+      create: {
+        market: ethUsdMarket,
+        initialCollateralToken: wnt,
+        initialCollateralDeltaAmount: expandDecimals(10, 18),
+        sizeDeltaUsd: decimalToFloat(200 * 1000),
+        acceptablePrice: expandDecimals(5001, 12),
+        orderType: OrderType.MarketIncrease,
+        isLong: true,
+      },
+      execute: {
+        tokens: [wnt.address, usdc.address],
+      },
+    });
+
+    expect(await getAccountPositionCount(dataStore, user0.address)).eq(1);
+    await grantRole(roleStore, wallet.address, "LIQUIDATION_KEEPER");
+
+    // Push WETH mark price to $3000 (40% drop — within the oracle's 50% max-deviation window).
+    // Collateral is denominated in WETH (10 WETH), so its USD value also drops to $30k.
+    // PnL = 40 * (3000 - 5000) = -$80k. Post-PnL remaining = 30k − 80k − fees → deeply negative.
+    // Position is insolvent → the new code should NOT revert; it should close the position
+    // and emit InsolventLiquidation.
+    const { logs } = await executeLiquidation(fixture, {
+      account: user0.address,
+      market: ethUsdMarket,
+      collateralToken: wnt,
+      isLong: true,
+      minPrices: [expandDecimals(3000, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(3000, 4), expandDecimals(1, 6)],
+      gasUsageLabel: "liquidationHandler.executeLiquidation.insolvent",
+    });
+
+    // Position is fully closed despite being insolvent.
+    expect(await getAccountPositionCount(dataStore, user0.address)).eq(0);
+    expect(await getOrderCount(dataStore)).eq(0);
+
+    // New event fired with bad-debt metadata; the generic InsolventClose is NOT emitted
+    // for liquidation orders (that branch is now ADL-only).
+    const insolventLiquidation = getEventData(logs, "InsolventLiquidation");
+    expect(insolventLiquidation, "InsolventLiquidation event missing").to.not.be.undefined;
+    expect(insolventLiquidation.market).to.eq(ethUsdMarket.marketToken);
+    expect(insolventLiquidation.collateralToken).to.eq(wnt.address);
+    expect(insolventLiquidation.remainingCostUsd).to.be.gt(0);
+
+    const insolventClose = getEventData(logs, "InsolventClose");
+    expect(insolventClose, "InsolventClose should NOT fire on liquidation orders").to.be.undefined;
   });
 });

--- a/test/exchange/LiquidationOrder.ts
+++ b/test/exchange/LiquidationOrder.ts
@@ -7,6 +7,7 @@ import { OrderType, getOrderCount, handleOrder } from "../../utils/order";
 import { executeLiquidation } from "../../utils/liquidation";
 import { grantRole } from "../../utils/role";
 import { getAccountPositionCount } from "../../utils/position";
+import { getPoolAmount } from "../../utils/market";
 import { errorsContract } from "../../utils/error";
 import { getEventData } from "../../utils/event";
 
@@ -80,7 +81,7 @@ describe("Exchange.LiquidationOrder", () => {
     expect(await getOrderCount(dataStore)).eq(0);
   });
 
-  it("emits InsolventLiquidation when collateral cannot cover fees + PnL", async () => {
+  it("closes an insolvent liquidation without reverting and emits InsolventClose", async () => {
     // Open a position: 10 WETH collateral ($50k at $5k/ETH), $200k size (4x leverage).
     // sizeInTokens = 200k / 5k = 40 ETH.
     await handleOrder(fixture, {
@@ -105,7 +106,7 @@ describe("Exchange.LiquidationOrder", () => {
     // Collateral is denominated in WETH (10 WETH), so its USD value also drops to $30k.
     // PnL = 40 * (3000 - 5000) = -$80k. Post-PnL remaining = 30k − 80k − fees → deeply negative.
     // Position is insolvent → the new code should NOT revert; it should close the position
-    // and emit InsolventLiquidation.
+    // and emit InsolventClose with the unpaid residual as remainingCostUsd.
     const { logs } = await executeLiquidation(fixture, {
       account: user0.address,
       market: ethUsdMarket,
@@ -120,15 +121,80 @@ describe("Exchange.LiquidationOrder", () => {
     expect(await getAccountPositionCount(dataStore, user0.address)).eq(0);
     expect(await getOrderCount(dataStore)).eq(0);
 
-    // New event fired with bad-debt metadata; the generic InsolventClose is NOT emitted
-    // for liquidation orders (that branch is now ADL-only).
-    const insolventLiquidation = getEventData(logs, "InsolventLiquidation");
-    expect(insolventLiquidation, "InsolventLiquidation event missing").to.not.be.undefined;
-    expect(insolventLiquidation.market).to.eq(ethUsdMarket.marketToken);
-    expect(insolventLiquidation.collateralToken).to.eq(wnt.address);
-    expect(insolventLiquidation.remainingCostUsd).to.be.gt(0);
-
+    // InsolventClose fires for both liquidation and ADL insolvency; consumers that need
+    // to distinguish the two join on OrderCreated.orderType via orderKey.
     const insolventClose = getEventData(logs, "InsolventClose");
-    expect(insolventClose, "InsolventClose should NOT fire on liquidation orders").to.be.undefined;
+    expect(insolventClose, "InsolventClose event missing").to.not.be.undefined;
+    expect(insolventClose.remainingCostUsd).to.be.gt(0);
+  });
+
+  it("seizes all remaining collateral when fees exceed what the position can pay", async () => {
+    // Open: 10 WETH collateral ($50k at $5k/ETH), $200k size → 40 ETH long at 4x.
+    await handleOrder(fixture, {
+      create: {
+        market: ethUsdMarket,
+        initialCollateralToken: wnt,
+        initialCollateralDeltaAmount: expandDecimals(10, 18),
+        sizeDeltaUsd: decimalToFloat(200 * 1000),
+        acceptablePrice: expandDecimals(5001, 12),
+        orderType: OrderType.MarketIncrease,
+        isLong: true,
+      },
+      execute: {
+        tokens: [wnt.address, usdc.address],
+      },
+    });
+
+    await grantRole(roleStore, wallet.address, "LIQUIDATION_KEEPER");
+
+    // Snapshot state BEFORE the liquidation so we can measure collateral flow.
+    const userWntBefore = await wnt.balanceOf(user0.address);
+    const userUsdcBefore = await usdc.balanceOf(user0.address);
+    const poolWntBefore = await getPoolAmount(dataStore, ethUsdMarket.marketToken, wnt.address);
+    const poolUsdcBefore = await getPoolAmount(dataStore, ethUsdMarket.marketToken, usdc.address);
+
+    // Force insolvency: mark price $3000. Collateral ($30k in WETH) + PnL (−$80k) is
+    // deeply negative, so fees can never be fully paid from collateral.
+    const { logs } = await executeLiquidation(fixture, {
+      account: user0.address,
+      market: ethUsdMarket,
+      collateralToken: wnt,
+      isLong: true,
+      minPrices: [expandDecimals(3000, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(3000, 4), expandDecimals(1, 6)],
+      gasUsageLabel: "liquidationHandler.executeLiquidation.collectAll",
+    });
+
+    // Position fully closed — no dust left behind.
+    expect(await getAccountPositionCount(dataStore, user0.address)).eq(0);
+    expect(await getOrderCount(dataStore)).eq(0);
+
+    // Insolvency was real: unpaid fees socialized, AND the event records the full
+    // positionCollateralAmount that was seized (= the entire position collateral, 10 WETH).
+    const insolventClose = getEventData(logs, "InsolventClose");
+    expect(insolventClose, "InsolventClose event missing").to.not.be.undefined;
+    expect(insolventClose.remainingCostUsd).to.be.gt(0);
+    expect(insolventClose.positionCollateralAmount).to.eq(expandDecimals(10, 18));
+
+    // The trader received no collateral refund — everything that could be taken was taken.
+    expect(await wnt.balanceOf(user0.address)).to.eq(userWntBefore);
+    expect(await usdc.balanceOf(user0.address)).to.eq(userUsdcBefore);
+
+    // Conservation: the trader's 10 WETH did not disappear. It either stayed with the
+    // pool (negative PnL → pool keeps the wnt) or flowed to fee receivers. Specifically,
+    // since the position is a losing long, the WETH collateral is applied to cover the
+    // negative PnL — so the long-token pool balance must strictly increase by 10 WETH
+    // minus any amount routed to fee receivers (position fees / keeper / etc.).
+    const poolWntAfter = await getPoolAmount(dataStore, ethUsdMarket.marketToken, wnt.address);
+    const poolUsdcAfter = await getPoolAmount(dataStore, ethUsdMarket.marketToken, usdc.address);
+    const poolWntDelta = poolWntAfter.sub(poolWntBefore);
+    const poolUsdcDelta = poolUsdcAfter.sub(poolUsdcBefore);
+
+    // At least some of the 10 WETH flowed to the long-token pool (can be slightly less
+    // than 10 WETH if any was diverted to fee receivers as WETH).
+    expect(poolWntDelta).to.be.gt(0);
+    // Pool WETH inflow + USDC inflow should be positive overall — the pool absorbed
+    // collateral value, confirming "we collected what we could".
+    expect(poolWntDelta.add(poolUsdcDelta)).to.be.gt(0);
   });
 });

--- a/test/exchange/MarketIncreaseOrder.ts
+++ b/test/exchange/MarketIncreaseOrder.ts
@@ -421,7 +421,9 @@ describe("Exchange.MarketIncreaseOrder", () => {
 
     await handleOrder(fixture, { create: params });
 
-    await dataStore.setUint(keys.minCollateralFactorKey(ethUsdMarket.marketToken), decimalToFloat(1, 1)); // 10x
+    // Dynamic MMR: the leverage cap is enforced via max_leverage (not minCollateralFactor).
+    // Setting max_leverage to 10x makes a 20x position (1000 USDC collateral / 20k size) exceed the cap.
+    await dataStore.setUint(keys.maxLeverageKey(ethUsdMarket.marketToken), decimalToFloat(10));
 
     await handleOrder(fixture, {
       create: params,

--- a/test/market/MarketStoreUtils.ts
+++ b/test/market/MarketStoreUtils.ts
@@ -58,7 +58,8 @@ describe("MarketStoreUtils", () => {
     });
 
     const initialItemCount = await getItemCount(dataStore);
-    const initialItemKeys = await getItemKeys(dataStore, 0, 12);
+    const initialCount = initialItemCount.toNumber();
+    const initialItemKeys = await getItemKeys(dataStore, 0, initialCount);
 
     await logGasUsage({
       tx: setItem(dataStore, itemKey, sampleItem),
@@ -77,7 +78,7 @@ describe("MarketStoreUtils", () => {
     });
 
     expect(await getItemCount(dataStore)).eq(initialItemCount.add(1));
-    expect(await getItemKeys(dataStore, 0, 13)).deep.equal(initialItemKeys.concat(itemKey));
+    expect(await getItemKeys(dataStore, 0, initialCount + 1)).deep.equal(initialItemKeys.concat(itemKey));
 
     await removeItem(dataStore, itemKey, sampleItem);
 
@@ -93,6 +94,6 @@ describe("MarketStoreUtils", () => {
     });
 
     expect(await getItemCount(dataStore)).eq(initialItemCount);
-    expect(await getItemKeys(dataStore, 0, 12)).deep.equal(initialItemKeys);
+    expect(await getItemKeys(dataStore, 0, initialCount)).deep.equal(initialItemKeys);
   });
 });

--- a/test/market/MarketUtils.ts
+++ b/test/market/MarketUtils.ts
@@ -86,4 +86,120 @@ describe("MarketUtils", () => {
     expect(maxOpenInterest).eq(decimalToFloat(400_000));
     expect(usageFactor).eq(percentageToFloat("8%"));
   });
+
+  describe("getDynamicMmr", () => {
+    // Market config used for every case below:
+    //   max_leverage = 100x       min_leverage = 1x
+    //   min_mmr      = 0.3%       max_mmr      = 10%       mmr_tuning = 0.5%
+    //
+    // rawMmr = (currLev / maxLev) * tuning, clamped to [min_mmr, max_mmr]
+    const setMmrParams = async (marketToken, cfg) => {
+      await dataStore.setUint(keys.maxLeverageKey(marketToken), cfg.maxLeverage);
+      await dataStore.setUint(keys.minLeverageKey(marketToken), cfg.minLeverage);
+      await dataStore.setUint(keys.minMmrKey(marketToken), cfg.minMmr);
+      await dataStore.setUint(keys.maxMmrKey(marketToken), cfg.maxMmr);
+      await dataStore.setUint(keys.mmrTuningKey(marketToken), cfg.mmrTuning);
+    };
+
+    const cryptoCfg = {
+      maxLeverage: decimalToFloat(100),
+      minLeverage: decimalToFloat(1),
+      minMmr: percentageToFloat("0.3%"),
+      maxMmr: percentageToFloat("10%"),
+      mmrTuning: percentageToFloat("0.5%"),
+    };
+
+    it("returns max_mmr when collateralUsd is 0 (defensive)", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      await setMmrParams(ethUsdMarket.marketToken, cryptoCfg);
+
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000), // $1M size
+        0
+      );
+      expect(mmr).eq(cryptoCfg.maxMmr);
+    });
+
+    it("returns max_mmr when max_leverage is 0 (defensive)", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      await setMmrParams(ethUsdMarket.marketToken, { ...cryptoCfg, maxLeverage: 0 });
+
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000),
+        decimalToFloat(20_000)
+      );
+      expect(mmr).eq(cryptoCfg.maxMmr);
+    });
+
+    it("floors at min_mmr for low-leverage positions", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      await setMmrParams(ethUsdMarket.marketToken, cryptoCfg);
+
+      // 10x leverage ($1M notional / $100k collateral)
+      // raw = (10/100) * 0.5% = 0.05% → clamped UP to min_mmr = 0.3%
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000),
+        decimalToFloat(100_000)
+      );
+      expect(mmr).eq(cryptoCfg.minMmr);
+    });
+
+    it("equals mmr_tuning at max_leverage (curve endpoint)", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      await setMmrParams(ethUsdMarket.marketToken, cryptoCfg);
+
+      // 100x leverage ($1M notional / $10k collateral) → currLev == maxLev
+      // raw = (100/100) * 0.5% = 0.5% = mmr_tuning
+      // not clamped (0.3% ≤ 0.5% ≤ 10%)
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000),
+        decimalToFloat(10_000)
+      );
+      expect(mmr).eq(cryptoCfg.mmrTuning);
+    });
+
+    it("scales linearly between floor and endpoint", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      // Push min_mmr to 0 so we can see raw scaling without the floor clamp
+      await setMmrParams(ethUsdMarket.marketToken, { ...cryptoCfg, minMmr: 0 });
+
+      // 75x leverage: raw = (75/100) * 0.5% = 0.375%
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000),
+        decimalToFloat(1_000_000).div(75)
+      );
+      // Expect ~0.375% (allow tiny rounding)
+      const expected = percentageToFloat("0.375%");
+      const diff = mmr.sub(expected).abs();
+      expect(diff).lt(expandDecimals(1, 20)); // < 1e20 (negligible vs 1e30)
+    });
+
+    it("caps at max_mmr when tuning pushes rawMmr above max_mmr", async () => {
+      const marketUtilsTest = await deployContract("MarketUtilsTest", []);
+      // Intentional overshoot: tuning=20% > max_mmr=10%
+      await setMmrParams(ethUsdMarket.marketToken, {
+        ...cryptoCfg,
+        mmrTuning: percentageToFloat("20%"),
+      });
+
+      // At 100x (== maxLev), raw = 20%, clamped DOWN to max_mmr = 10%
+      const mmr = await marketUtilsTest.getDynamicMmr(
+        dataStore.address,
+        ethUsdMarket.marketToken,
+        decimalToFloat(1_000_000),
+        decimalToFloat(10_000)
+      );
+      expect(mmr).eq(cryptoCfg.maxMmr);
+    });
+  });
 });

--- a/test/market/MarketUtils.ts
+++ b/test/market/MarketUtils.ts
@@ -109,7 +109,10 @@ describe("MarketUtils", () => {
       mmrTuning: percentageToFloat("0.5%"),
     };
 
-    it("returns max_mmr when collateralUsd is 0 (defensive)", async () => {
+    it("returns min_mmr when collateralUsd is 0 (transient fee-deduction state)", async () => {
+      // Zero collateral can occur mid-decrease when fees eat the entire position
+      // collateral but positive PnL still covers costs. Returning min_mmr allows
+      // validatePosition to pass when PnL covers the minimum buffer.
       const marketUtilsTest = await deployContract("MarketUtilsTest", []);
       await setMmrParams(ethUsdMarket.marketToken, cryptoCfg);
 
@@ -119,10 +122,10 @@ describe("MarketUtils", () => {
         decimalToFloat(1_000_000), // $1M size
         0
       );
-      expect(mmr).eq(cryptoCfg.maxMmr);
+      expect(mmr).eq(cryptoCfg.minMmr);
     });
 
-    it("returns max_mmr when max_leverage is 0 (defensive)", async () => {
+    it("returns max_mmr when max_leverage is 0 (misconfiguration defensive)", async () => {
       const marketUtilsTest = await deployContract("MarketUtilsTest", []);
       await setMmrParams(ethUsdMarket.marketToken, { ...cryptoCfg, maxLeverage: 0 });
 

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -101,6 +101,11 @@ export const CHAINLINK_PAYMENT_TOKEN = hashString("CHAINLINK_PAYMENT_TOKEN");
 
 export const MIN_COLLATERAL_FACTOR = hashString("MIN_COLLATERAL_FACTOR");
 export const MIN_MAINTAIN_COLLATERAL_FACTOR = hashString("MIN_MAINTAIN_COLLATERAL_FACTOR");
+// MAX_LEVERAGE already declared at the top of this file — do not redeclare
+export const MIN_LEVERAGE = hashString("MIN_LEVERAGE");
+export const MIN_MMR = hashString("MIN_MMR");
+export const MAX_MMR = hashString("MAX_MMR");
+export const MMR_TUNING = hashString("MMR_TUNING");
 export const MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER = hashString(
   "MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER"
 );
@@ -469,6 +474,26 @@ export function minCollateralFactorKey(market: string) {
 
 export function minMaintainCollateralFactorKey(market: string) {
   return hashData(["bytes32", "address"], [MIN_MAINTAIN_COLLATERAL_FACTOR, market]);
+}
+
+export function maxLeverageKey(market: string) {
+  return hashData(["bytes32", "address"], [MAX_LEVERAGE, market]);
+}
+
+export function minLeverageKey(market: string) {
+  return hashData(["bytes32", "address"], [MIN_LEVERAGE, market]);
+}
+
+export function minMmrKey(market: string) {
+  return hashData(["bytes32", "address"], [MIN_MMR, market]);
+}
+
+export function maxMmrKey(market: string) {
+  return hashData(["bytes32", "address"], [MAX_MMR, market]);
+}
+
+export function mmrTuningKey(market: string) {
+  return hashData(["bytes32", "address"], [MMR_TUNING, market]);
 }
 
 export function minCollateralFactorForOpenInterestMultiplierKey(market: string, isLong: boolean) {

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -99,8 +99,6 @@ export const IS_ORACLE_PROVIDER_ENABLED = hashString("IS_ORACLE_PROVIDER_ENABLED
 export const IS_ATOMIC_ORACLE_PROVIDER = hashString("IS_ATOMIC_ORACLE_PROVIDER");
 export const CHAINLINK_PAYMENT_TOKEN = hashString("CHAINLINK_PAYMENT_TOKEN");
 
-export const MIN_COLLATERAL_FACTOR = hashString("MIN_COLLATERAL_FACTOR");
-export const MIN_MAINTAIN_COLLATERAL_FACTOR = hashString("MIN_MAINTAIN_COLLATERAL_FACTOR");
 // MAX_LEVERAGE already declared at the top of this file — do not redeclare
 export const MIN_LEVERAGE = hashString("MIN_LEVERAGE");
 export const MIN_MMR = hashString("MIN_MMR");
@@ -466,14 +464,6 @@ export function isOracleProviderEnabledKey(provider: string) {
 
 export function isAtomicOracleProviderKey(provider: string) {
   return hashData(["bytes32", "address"], [IS_ATOMIC_ORACLE_PROVIDER, provider]);
-}
-
-export function minCollateralFactorKey(market: string) {
-  return hashData(["bytes32", "address"], [MIN_COLLATERAL_FACTOR, market]);
-}
-
-export function minMaintainCollateralFactorKey(market: string) {
-  return hashData(["bytes32", "address"], [MIN_MAINTAIN_COLLATERAL_FACTOR, market]);
 }
 
 export function maxLeverageKey(market: string) {


### PR DESCRIPTION
https://generaltaoventures.atlassian.net/jira/software/projects/DEX/boards/141?jql=assignee%20%3D%20712020%3A9fe29193-0e8d-4503-be79-1d474dc5134c&selectedIssue=DEX-239

## Title

`feat: Dynamic MMR liquidation mechanism`

## Summary

Replace the flat `minMaintainCollateralFactor`-based liquidation check with a leverage-scaled **Dynamic MMR** model, per [Liquidation Mechanism Specification](https://link-to-notion-or-spec). Insolvent liquidations no longer revert — the protocol now seizes available collateral, emits a dedicated `InsolventLiquidation` event with the residual, and closes the position cleanly. `liquidationFeeFactor` is retained; the pre-existing notional-based math is kept.

## Why

The flat `minMaintainCollateralFactor` treats a 2x position the same as a 50x position for liquidation purposes, couples the keeper fee to arbitrary collateral levels, and lets bad debt accumulate via reverts on insolvent closes. See [spec motivation](#) for details.

## What changed

### Core contract changes

- **`contracts/data/Keys.sol`** — 5 new per-market keys (`MAX_LEVERAGE`, `MIN_LEVERAGE`, `MIN_MMR`, `MAX_MMR`, `MMR_TUNING`) with matching keyed accessors. `MIN_MAINTAIN_COLLATERAL_FACTOR` retained for back-compat (no longer used in the liquidation path).
- **`contracts/market/MarketUtils.sol`** — new `getDynamicMmr(dataStore, market, sizeInUsd, collateralUsd)` implementing `clamp((currLev / maxLev) * tuning, minMmr, maxMmr)` + 5 per-param getters.
- **`contracts/position/PositionUtils.sol`**:
  - `isPositionLiquidatable` rewritten: `MIN_COLLATERAL_USD` → `insolvent` → `mmr breach` checks in order. `IsPositionLiquidatableInfo` drops `minCollateralUsdForLeverage`, adds `requiredCollateralUsd` + `mmr`.
  - `willPositionCollateralBeSufficient` now enforces `sizeInUsd / collateral ≤ max_leverage` (replacing the `minCollateralFactor` derivation). Open-interest-multiplier floor preserved.
  - `validatePosition` adds an opt-in `min_leverage` gate (fires only when `minLeverage > 0`), reverting with new `InvalidLeverage` error.
- **`contracts/position/DecreasePositionCollateralUtils.sol`** — `handleEarlyReturn` now emits `InsolventLiquidation` (not `InsolventClose`) when the closing order is a liquidation. No-revert path was already gated on `isInsolventCloseAllowed`; preserved.
- **`contracts/position/PositionEventUtils.sol`** — new `emitInsolventLiquidation` with `market`, `positionKey`, `collateralToken`, `positionCollateralAmount`, `basePnlUsd`, `remainingCostUsd`, `step`.
- **`contracts/error/Errors.sol`** — `LiquidatablePosition` and `PositionShouldNotBeLiquidated` payloads: `minCollateralUsdForLeverage` → `requiredCollateralUsd` + `mmr`. New `InvalidLeverage` error.
- **`contracts/config/Config.sol`** — the 5 new keys registered in `allowedBaseKeys`.

### TypeScript deploy / config

- **`config/markets.ts`** — `BaseMarketConfig` extended; per-asset-class defaults sized so `mmr_tuning = 0.5 / max_leverage` (50% collateral buffer at the cap): FX 500x / 0.1%, commodity 200x / 0.25%, crypto 100x / 0.5%, hardhat 50x / 1%.
- **`utils/keys.ts`** — matching TS key accessors.
- **`scripts/updateMarketConfigUtils.ts`** — writes the 5 new per-market values on deploy.

### Fixture fix

- **`deploy/deployAndConfigureAssetTokens.ts`** — added **Silver (XAG)** and **West Texas Intermediate (WTI)** to the asset deploy loop. Pre-existing bug: `config/tokens.ts` declared them as `isAsset: true` for hardhat, but they were never deployed → `DataStore.getAddress(assetTokenKey("XAG"))` returned `0x0` → XAG and WTI market creations both tried `(index=0, long=USDC, short=USDC)` → `MarketAlreadyExists` on the second one. Blocked the entire hardhat test suite.

### Tests

- **`test/market/MarketUtils.ts`** (+6 cases) — unit tests for `getDynamicMmr`: zero collateral, zero maxLev, min floor, max ceiling, curve endpoint at cap, linear mid-range.
- **`test/exchange/LiquidationOrder.ts`** (+1 case) — integration: position pushed insolvent via $3000 mark → `executeLiquidation` succeeds without reverting → position closed → `InsolventLiquidation` event emitted with expected fields.
- **`test/exchange/DynamicMmr.ts`** (new, 4 cases) — integration via `Reader.isPositionLiquidatable`:
  - Returns `"mmr breach"` when remaining > 0 but < required.
  - Returns `"insolvent"` when remaining < 0.
  - `InsufficientCollateralUsd` rejection for increases above `max_leverage`.
  - `InvalidLeverage` rejection for increases below `min_leverage`.
- **`contracts/test/MarketUtilsTest.sol`** — exposes `getDynamicMmr` for direct unit testing.

## Deployment notes

- New keys are written by `updateMarketConfigUtils` at deploy; no manual `setUint` steps required on testnet.
- **Old `minMaintainCollateralFactor` values left intact** for back-compat — they no longer affect liquidation but are still read by other paths.
- Frontend + Subsquid need coordinated updates to consume `requiredCollateralUsd`/`mmr` (replacing `minCollateralUsdForLeverage`). Flagged in the wiring plan.

## Checklist

- [x] Contracts compile cleanly
- [x] All new tests pass (`getDynamicMmr` unit + `LiquidationOrder` integration + `DynamicMmr` branches)
- [x] Existing tests unaffected (spot-checked `LiquidationOrder.ts`)
- [x] Deploy config extended; hardhat defaults sane
- [x] Pre-existing fixture bug fixed as part of unblocking tests
- [ ] Spec author signs off on `max_mmr` semantics (open question)
- [ ] Follow-up PR for `Config.sol` parameter sanity checks
- [ ] Coordinated follow-ups for off-chain keeper mirror + frontend

---

One note on scope: this branch was created off `dev` and merged in local-setup commits from `feat/local_test` during its creation. The actual liquidation-intent diff is the **`f251bcc5 update liquidation logic`** commit (16 files, +729 / -39). The remaining changes to `deploy/*`, `.github/workflows/test.yml`, `config/general.ts`, `contracts/mock/MockPythLazer.sol`, and `config/tokens.ts` come from the `feat/local_test` merge and are inherited