### PR TITLE
Feat/dual oracle circuit breaker

### DIFF
--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -507,6 +507,8 @@ library Keys {
     bytes32 public constant CIRCUIT_BREAKER_TIMESTAMP_SKEW = keccak256(abi.encode("CIRCUIT_BREAKER_TIMESTAMP_SKEW"));
     // @dev key for marking an address as an authorized caller of ChainlinkDataStreamProvider (in addition to the Oracle contract)
     bytes32 public constant IS_DATA_STREAM_AUTHORIZED_CALLER = keccak256(abi.encode("IS_DATA_STREAM_AUTHORIZED_CALLER"));
+    // @dev key for allowing a per-token hybrid oracle to fall back to a single feed when the other is unavailable
+    bytes32 public constant ALLOW_SINGLE_ORACLE_FALLBACK = keccak256(abi.encode("ALLOW_SINGLE_ORACLE_FALLBACK"));
 
 
     // @dev function used to calculate fullKey for a given market parameter
@@ -2248,6 +2250,16 @@ library Keys {
         return keccak256(abi.encode(
             IS_DATA_STREAM_AUTHORIZED_CALLER,
             caller
+        ));
+    }
+
+    // @dev key for allowing the hybrid oracle to fall back to a single feed for this token
+    // @param token the token to check
+    // @return key for the per-token single-oracle-fallback allow flag
+    function allowSingleOracleFallbackKey(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            ALLOW_SINGLE_ORACLE_FALLBACK,
+            token
         ));
     }
 }

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -501,6 +501,13 @@ library Keys {
     // @dev key for Pyth Lazer feed multiplier
     bytes32 public constant PYTH_LAZER_FEED_MULTIPLIER = keccak256(abi.encode("PYTH_LAZER_FEED_MULTIPLIER"));
 
+    // @dev key for per-token max allowed deviation (in bps) between primary and secondary oracles in the circuit breaker
+    bytes32 public constant CIRCUIT_BREAKER_DEVIATION_BPS = keccak256(abi.encode("CIRCUIT_BREAKER_DEVIATION_BPS"));
+    // @dev key for per-token max allowed timestamp skew (in seconds) between primary and secondary oracles
+    bytes32 public constant CIRCUIT_BREAKER_TIMESTAMP_SKEW = keccak256(abi.encode("CIRCUIT_BREAKER_TIMESTAMP_SKEW"));
+    // @dev key for marking an address as an authorized caller of ChainlinkDataStreamProvider (in addition to the Oracle contract)
+    bytes32 public constant IS_DATA_STREAM_AUTHORIZED_CALLER = keccak256(abi.encode("IS_DATA_STREAM_AUTHORIZED_CALLER"));
+
 
     // @dev function used to calculate fullKey for a given market parameter
     // @param baseKey the base key for the market parameter
@@ -2211,6 +2218,36 @@ library Keys {
         return keccak256(abi.encode(
             PYTH_LAZER_FEED_MULTIPLIER,
             token
+        ));
+    }
+
+    // @dev key for per-token circuit breaker max deviation in bps
+    // @param token the token to get the key for
+    // @return key for per-token max deviation between primary and secondary oracles, in bps
+    function circuitBreakerDeviationBpsKey(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            CIRCUIT_BREAKER_DEVIATION_BPS,
+            token
+        ));
+    }
+
+    // @dev key for per-token circuit breaker max timestamp skew in seconds
+    // @param token the token to get the key for
+    // @return key for per-token max allowed timestamp skew between primary and secondary oracle reports
+    function circuitBreakerTimestampSkewKey(address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            CIRCUIT_BREAKER_TIMESTAMP_SKEW,
+            token
+        ));
+    }
+
+    // @dev key for flagging an address as an authorized caller of ChainlinkDataStreamProvider
+    // @param caller the address to check
+    // @return key for the authorized caller flag
+    function isDataStreamAuthorizedCallerKey(address caller) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            IS_DATA_STREAM_AUTHORIZED_CALLER,
+            caller
         ));
     }
 }

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -257,6 +257,8 @@ library Errors {
         uint256 secondaryTimestamp,
         uint256 maxSkew
     );
+    error NoOracleData(address token);
+    error OracleSingleFallbackDisabled(address token);
 
     // OracleModule errors
     error InvalidPrimaryPricesForSimulation(uint256 primaryTokensLength, uint256 primaryPricesLength);

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -242,6 +242,22 @@ library Errors {
     error EmptyPythLazerFeedMultiplier(address token);
     error StaleOraclePrice(address token, uint256 publishedTimestamp, uint256 storedTimestamp);
 
+    // CircuitBreakerOracleProvider errors
+    error EmptyCircuitBreakerDeviationBps(address token);
+    error OracleCircuitBreakerDeviation(
+        address token,
+        uint256 primaryMid,
+        uint256 secondaryMid,
+        uint256 observedBps,
+        uint256 maxBps
+    );
+    error OracleCircuitBreakerTimestampSkew(
+        address token,
+        uint256 primaryTimestamp,
+        uint256 secondaryTimestamp,
+        uint256 maxSkew
+    );
+
     // OracleModule errors
     error InvalidPrimaryPricesForSimulation(uint256 primaryTokensLength, uint256 primaryPricesLength);
     error EndOfOracleSimulation();

--- a/contracts/oracle/ChainlinkDataStreamProvider.sol
+++ b/contracts/oracle/ChainlinkDataStreamProvider.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 
 import "../data/DataStore.sol";
 import "../data/Keys.sol";
+import "../error/Errors.sol";
 import "./IOracleProvider.sol";
 import "./IChainlinkDataStreamVerifier.sol";
 import "../utils/Precision.sol";
@@ -29,8 +30,15 @@ contract ChainlinkDataStreamProvider is IOracleProvider {
         int192 ask; // Simulated price impact of a sell order up to the X% depth of liquidity utilisation
     }
 
+    // @dev Permits the Oracle contract or any address flagged via
+    //      Keys.isDataStreamAuthorizedCallerKey(caller) in DataStore.
+    //      The allowlist lets composite providers (e.g. CircuitBreakerOracleProvider)
+    //      delegate here without making the Oracle contract the sole caller.
     modifier onlyOracle() {
-        if (msg.sender != oracle) {
+        if (
+            msg.sender != oracle &&
+            !dataStore.getBool(Keys.isDataStreamAuthorizedCallerKey(msg.sender))
+        ) {
             revert Errors.Unauthorized(msg.sender, "Oracle");
         }
         _;

--- a/contracts/oracle/CircuitBreakerOracleProvider.sol
+++ b/contracts/oracle/CircuitBreakerOracleProvider.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../data/DataStore.sol";
+import "../data/Keys.sol";
+import "../error/Errors.sol";
+import "../utils/Precision.sol";
+import "./IOracleProvider.sol";
+import "./OracleUtils.sol";
+
+// @title CircuitBreakerOracleProvider
+// @dev Dual-oracle wrapper. Fetches a price from two underlying providers
+//      (primary + secondary, e.g. Pyth Lazer + Chainlink Data Streams),
+//      applies a reconciliation policy, and returns a single ValidatedPrice.
+//      Reverts the trade if the policy rejects the pair.
+//
+//      The keeper must pack the `data` blob as:
+//          abi.encode(bytes primaryData, bytes secondaryData)
+//      which is unpacked here and routed to each underlying provider.
+//
+// @dev ACCESS CONTROL NOTE: ChainlinkDataStreamProvider enforces onlyOracle.
+//      If `secondary` is that contract, the delegating call below will revert
+//      because msg.sender (this wrapper) != oracle. See TODO in constructor.
+contract CircuitBreakerOracleProvider is IOracleProvider {
+    DataStore public immutable dataStore;
+    IOracleProvider public immutable primary;
+    IOracleProvider public immutable secondary;
+
+    constructor(
+        DataStore _dataStore,
+        IOracleProvider _primary,
+        IOracleProvider _secondary
+    ) {
+        // TODO(access-control): Before deploying, pick ONE of:
+        //   (a) relax onlyOracle in ChainlinkDataStreamProvider to allow this wrapper
+        //   (b) add a setAuthorizedCaller(address) allowlist to ChainlinkDataStreamProvider
+        //   (c) rewrite this wrapper to call IChainlinkDataStreamVerifier.verify() directly
+        //       (duplicates the Chainlink parsing logic — auditable, no upstream changes)
+        dataStore = _dataStore;
+        primary = _primary;
+        secondary = _secondary;
+    }
+
+    // Forward ETH so PythLazer verification fees can be covered when primary is PythLazer.
+    receive() external payable {}
+
+    function getOraclePrice(
+        address token,
+        bytes memory data
+    ) external returns (OracleUtils.ValidatedPrice memory) {
+        (bytes memory primaryData, bytes memory secondaryData) = abi.decode(
+            data,
+            (bytes, bytes)
+        );
+
+        OracleUtils.ValidatedPrice memory primaryPrice = primary.getOraclePrice(
+            token,
+            primaryData
+        );
+        OracleUtils.ValidatedPrice memory secondaryPrice = secondary.getOraclePrice(
+            token,
+            secondaryData
+        );
+
+        return _reconcilePrices(token, primaryPrice, secondaryPrice);
+    }
+
+    // -------------------------------------------------------------------------
+    //
+    //                    *** IMPLEMENT YOUR POLICY HERE ***
+    //
+    // This is the actual circuit breaker. Given two ValidatedPrices for the
+    // same token, decide whether the pair is acceptable and what to return.
+    //
+    // Both `.min` and `.max` are 30-decimal fixed-point (1e30 == $1). They
+    // represent bid / ask respectively. Precision.FLOAT_PRECISION = 1e30.
+    //
+    // Design questions you must answer in code:
+    //
+    //   1. DEVIATION CHECK — how do you measure disagreement?
+    //        Option: midpoint-vs-midpoint deviation in bps
+    //          mid_p = (primaryPrice.min + primaryPrice.max) / 2
+    //          mid_s = (secondaryPrice.min + secondaryPrice.max) / 2
+    //          deviationBps = |mid_p - mid_s| * 10_000 / mid_p
+    //        Option: per-side (min-to-min AND max-to-max must both be within band)
+    //
+    //   2. THRESHOLD — where does the threshold live?
+    //        Option: hardcoded constant (simplest, safest to audit)
+    //        Option: per-token DataStore key (tune majors vs alts without redeploy)
+    //          e.g. dataStore.getUint(Keys.circuitBreakerDeviationBpsKey(token))
+    //
+    //   3. TIMESTAMP SKEW — reject if the two feeds disagree on WHEN?
+    //        Pyth Lazer is sub-second, Chainlink Data Streams is slower.
+    //        Suggested tolerance: 2-5 seconds. Use block.timestamp as reference
+    //        if you want to reject stale secondary too.
+    //
+    //   4. RETURN POLICY — which price do you hand back if the check passes?
+    //        Option: primary (trust Pyth, Chainlink was only a sanity check)
+    //        Option: defensive — return the WORSE pair for the trader:
+    //              min: Math.min(primary.min, secondary.min)
+    //              max: Math.max(primary.max, secondary.max)
+    //          This widens spread on disagreement, protocol-friendly
+    //        Option: midpoint blend (loses bid/ask signal — avoid)
+    //
+    //   5. ERROR SURFACE — on rejection, revert with a typed error:
+    //        Add to contracts/error/Errors.sol:
+    //          error OracleCircuitBreakerDeviation(
+    //              address token,
+    //              uint256 primaryMid,
+    //              uint256 secondaryMid,
+    //              uint256 observedBps,
+    //              uint256 maxBps
+    //          );
+    //          error OracleCircuitBreakerTimestampSkew(
+    //              address token,
+    //              uint256 primaryTs,
+    //              uint256 secondaryTs
+    //          );
+    //
+    // Keep it under ~15 lines. If you reach for complex logic, it probably
+    // belongs in a helper library, not the policy function.
+    //
+    // -------------------------------------------------------------------------
+    function _reconcilePrices(
+        address token,
+        OracleUtils.ValidatedPrice memory primaryPrice,
+        OracleUtils.ValidatedPrice memory secondaryPrice
+    ) internal view returns (OracleUtils.ValidatedPrice memory) {
+        // TODO(ken): implement reconciliation policy per comment block above.
+        revert("CircuitBreakerOracleProvider: _reconcilePrices not implemented");
+    }
+}

--- a/contracts/oracle/CircuitBreakerOracleProvider.sol
+++ b/contracts/oracle/CircuitBreakerOracleProvider.sol
@@ -12,17 +12,26 @@ import "./OracleUtils.sol";
 // @title CircuitBreakerOracleProvider
 // @dev Dual-oracle wrapper. Fetches a price from two underlying providers
 //      (primary + secondary, e.g. Pyth Lazer + Chainlink Data Streams),
-//      applies a reconciliation policy, and returns a single ValidatedPrice.
-//      Reverts the trade if the policy rejects the pair.
+//      reconciles them via a deviation check + timestamp skew check, and
+//      returns a defensive ValidatedPrice (widened spread) if accepted.
 //
-//      The keeper must pack the `data` blob as:
+//      Reverts the trade if either check fails.
+//
+//      The keeper packs `data` as:
 //          abi.encode(bytes primaryData, bytes secondaryData)
 //      which is unpacked here and routed to each underlying provider.
 //
-// @dev ACCESS CONTROL NOTE: ChainlinkDataStreamProvider enforces onlyOracle.
-//      If `secondary` is that contract, the delegating call below will revert
-//      because msg.sender (this wrapper) != oracle. See TODO in constructor.
+// @dev Per-token config in DataStore (governance via Config.sol):
+//        Keys.circuitBreakerDeviationBpsKey(token)   — REQUIRED, bps (uint)
+//        Keys.circuitBreakerTimestampSkewKey(token)  — OPTIONAL, seconds (uint), default 5
+//
+// @dev If `secondary` is ChainlinkDataStreamProvider, this wrapper's address
+//      must be flagged via Keys.isDataStreamAuthorizedCallerKey(wrapper) = true
+//      in DataStore before it can delegate there.
 contract CircuitBreakerOracleProvider is IOracleProvider {
+    uint256 private constant BPS_DIVISOR = 10_000;
+    uint256 private constant DEFAULT_TIMESTAMP_SKEW_SECONDS = 5;
+
     DataStore public immutable dataStore;
     IOracleProvider public immutable primary;
     IOracleProvider public immutable secondary;
@@ -32,11 +41,6 @@ contract CircuitBreakerOracleProvider is IOracleProvider {
         IOracleProvider _primary,
         IOracleProvider _secondary
     ) {
-        // TODO(access-control): Before deploying, pick ONE of:
-        //   (a) relax onlyOracle in ChainlinkDataStreamProvider to allow this wrapper
-        //   (b) add a setAuthorizedCaller(address) allowlist to ChainlinkDataStreamProvider
-        //   (c) rewrite this wrapper to call IChainlinkDataStreamVerifier.verify() directly
-        //       (duplicates the Chainlink parsing logic — auditable, no upstream changes)
         dataStore = _dataStore;
         primary = _primary;
         secondary = _secondary;
@@ -66,68 +70,71 @@ contract CircuitBreakerOracleProvider is IOracleProvider {
         return _reconcilePrices(token, primaryPrice, secondaryPrice);
     }
 
-    // -------------------------------------------------------------------------
-    //
-    //                    *** IMPLEMENT YOUR POLICY HERE ***
-    //
-    // This is the actual circuit breaker. Given two ValidatedPrices for the
-    // same token, decide whether the pair is acceptable and what to return.
-    //
-    // Both `.min` and `.max` are 30-decimal fixed-point (1e30 == $1). They
-    // represent bid / ask respectively. Precision.FLOAT_PRECISION = 1e30.
-    //
-    // Design questions you must answer in code:
-    //
-    //   1. DEVIATION CHECK — how do you measure disagreement?
-    //        Option: midpoint-vs-midpoint deviation in bps
-    //          mid_p = (primaryPrice.min + primaryPrice.max) / 2
-    //          mid_s = (secondaryPrice.min + secondaryPrice.max) / 2
-    //          deviationBps = |mid_p - mid_s| * 10_000 / mid_p
-    //        Option: per-side (min-to-min AND max-to-max must both be within band)
-    //
-    //   2. THRESHOLD — where does the threshold live?
-    //        Option: hardcoded constant (simplest, safest to audit)
-    //        Option: per-token DataStore key (tune majors vs alts without redeploy)
-    //          e.g. dataStore.getUint(Keys.circuitBreakerDeviationBpsKey(token))
-    //
-    //   3. TIMESTAMP SKEW — reject if the two feeds disagree on WHEN?
-    //        Pyth Lazer is sub-second, Chainlink Data Streams is slower.
-    //        Suggested tolerance: 2-5 seconds. Use block.timestamp as reference
-    //        if you want to reject stale secondary too.
-    //
-    //   4. RETURN POLICY — which price do you hand back if the check passes?
-    //        Option: primary (trust Pyth, Chainlink was only a sanity check)
-    //        Option: defensive — return the WORSE pair for the trader:
-    //              min: Math.min(primary.min, secondary.min)
-    //              max: Math.max(primary.max, secondary.max)
-    //          This widens spread on disagreement, protocol-friendly
-    //        Option: midpoint blend (loses bid/ask signal — avoid)
-    //
-    //   5. ERROR SURFACE — on rejection, revert with a typed error:
-    //        Add to contracts/error/Errors.sol:
-    //          error OracleCircuitBreakerDeviation(
-    //              address token,
-    //              uint256 primaryMid,
-    //              uint256 secondaryMid,
-    //              uint256 observedBps,
-    //              uint256 maxBps
-    //          );
-    //          error OracleCircuitBreakerTimestampSkew(
-    //              address token,
-    //              uint256 primaryTs,
-    //              uint256 secondaryTs
-    //          );
-    //
-    // Keep it under ~15 lines. If you reach for complex logic, it probably
-    // belongs in a helper library, not the policy function.
-    //
-    // -------------------------------------------------------------------------
+    // @dev Reconciliation policy:
+    //        1. Reject if timestamp skew between the two reports exceeds configured max.
+    //        2. Reject if midpoint-to-midpoint deviation exceeds per-token bps threshold.
+    //        3. Return the defensive (wider) pair: min of mins, max of maxes.
+    //        4. Return the OLDER of the two timestamps, so downstream staleness checks
+    //           catch a pair where one feed has drifted behind.
     function _reconcilePrices(
         address token,
         OracleUtils.ValidatedPrice memory primaryPrice,
         OracleUtils.ValidatedPrice memory secondaryPrice
     ) internal view returns (OracleUtils.ValidatedPrice memory) {
-        // TODO(ken): implement reconciliation policy per comment block above.
-        revert("CircuitBreakerOracleProvider: _reconcilePrices not implemented");
+        uint256 skew = primaryPrice.timestamp > secondaryPrice.timestamp
+            ? primaryPrice.timestamp - secondaryPrice.timestamp
+            : secondaryPrice.timestamp - primaryPrice.timestamp;
+
+        uint256 maxSkew = dataStore.getUint(Keys.circuitBreakerTimestampSkewKey(token));
+        if (maxSkew == 0) {
+            maxSkew = DEFAULT_TIMESTAMP_SKEW_SECONDS;
+        }
+        if (skew > maxSkew) {
+            revert Errors.OracleCircuitBreakerTimestampSkew(
+                token,
+                primaryPrice.timestamp,
+                secondaryPrice.timestamp,
+                maxSkew
+            );
+        }
+
+        uint256 maxBps = dataStore.getUint(Keys.circuitBreakerDeviationBpsKey(token));
+        if (maxBps == 0) {
+            revert Errors.EmptyCircuitBreakerDeviationBps(token);
+        }
+
+        uint256 primaryMid = (primaryPrice.min + primaryPrice.max) / 2;
+        uint256 secondaryMid = (secondaryPrice.min + secondaryPrice.max) / 2;
+        uint256 diff = primaryMid > secondaryMid
+            ? primaryMid - secondaryMid
+            : secondaryMid - primaryMid;
+        uint256 deviationBps = (diff * BPS_DIVISOR) / primaryMid;
+        if (deviationBps > maxBps) {
+            revert Errors.OracleCircuitBreakerDeviation(
+                token,
+                primaryMid,
+                secondaryMid,
+                deviationBps,
+                maxBps
+            );
+        }
+
+        uint256 defensiveMin = primaryPrice.min < secondaryPrice.min
+            ? primaryPrice.min
+            : secondaryPrice.min;
+        uint256 defensiveMax = primaryPrice.max > secondaryPrice.max
+            ? primaryPrice.max
+            : secondaryPrice.max;
+        uint256 olderTimestamp = primaryPrice.timestamp < secondaryPrice.timestamp
+            ? primaryPrice.timestamp
+            : secondaryPrice.timestamp;
+
+        return OracleUtils.ValidatedPrice({
+            token: token,
+            min: defensiveMin,
+            max: defensiveMax,
+            timestamp: olderTimestamp,
+            provider: address(this)
+        });
     }
 }

--- a/contracts/oracle/CircuitBreakerOracleProvider.sol
+++ b/contracts/oracle/CircuitBreakerOracleProvider.sol
@@ -10,20 +10,30 @@ import "./IOracleProvider.sol";
 import "./OracleUtils.sol";
 
 // @title CircuitBreakerOracleProvider
-// @dev Dual-oracle wrapper. Fetches a price from two underlying providers
-//      (primary + secondary, e.g. Pyth Lazer + Chainlink Data Streams),
-//      reconciles them via a deviation check + timestamp skew check, and
-//      returns a defensive ValidatedPrice (widened spread) if accepted.
+// @dev Hybrid dual-oracle wrapper. Three modes per-call, selected by which payloads
+//      the keeper provides:
 //
-//      Reverts the trade if either check fails.
+//        1. BOTH feeds available (circuit breaker):
+//           Deviation + timestamp-skew checks; revert if either fails.
+//           On pass, return a defensive price (wider min/max, older timestamp).
 //
-//      The keeper packs `data` as:
+//        2. ONE feed available (graceful degradation):
+//           Return that feed's price directly, emit OracleDegradedMode.
+//           ONLY allowed when Keys.allowSingleOracleFallbackKey(token) is true.
+//           Otherwise reverts with OracleSingleFallbackDisabled.
+//
+//        3. NEITHER feed available:
+//           Reverts with NoOracleData.
+//
+//      Keeper signals "unavailable" by sending an empty bytes payload (length 0)
+//      on that side. The keeper packs `data` as:
 //          abi.encode(bytes primaryData, bytes secondaryData)
-//      which is unpacked here and routed to each underlying provider.
 //
 // @dev Per-token config in DataStore (governance via Config.sol):
-//        Keys.circuitBreakerDeviationBpsKey(token)   — REQUIRED, bps (uint)
-//        Keys.circuitBreakerTimestampSkewKey(token)  — OPTIONAL, seconds (uint), default 5
+//        Keys.circuitBreakerDeviationBpsKey(token)   — REQUIRED when both feeds present
+//        Keys.circuitBreakerTimestampSkewKey(token)  — OPTIONAL, seconds, default 5
+//        Keys.allowSingleOracleFallbackKey(token)    — OPTIONAL, bool, default false
+//                                                      (must be true to allow mode 2)
 //
 // @dev If `secondary` is ChainlinkDataStreamProvider, this wrapper's address
 //      must be flagged via Keys.isDataStreamAuthorizedCallerKey(wrapper) = true
@@ -35,6 +45,11 @@ contract CircuitBreakerOracleProvider is IOracleProvider {
     DataStore public immutable dataStore;
     IOracleProvider public immutable primary;
     IOracleProvider public immutable secondary;
+
+    // @dev Emitted whenever the wrapper serves a price based on a single underlying
+    //      feed because the other was unavailable. Wire this up to monitoring — if it
+    //      fires frequently the market is effectively running single-oracle.
+    event OracleDegradedMode(address indexed token, bool usedSecondary);
 
     constructor(
         DataStore _dataStore,
@@ -58,16 +73,42 @@ contract CircuitBreakerOracleProvider is IOracleProvider {
             (bytes, bytes)
         );
 
-        OracleUtils.ValidatedPrice memory primaryPrice = primary.getOraclePrice(
-            token,
-            primaryData
-        );
-        OracleUtils.ValidatedPrice memory secondaryPrice = secondary.getOraclePrice(
-            token,
-            secondaryData
-        );
+        bool primaryAvailable = primaryData.length > 0;
+        bool secondaryAvailable = secondaryData.length > 0;
 
-        return _reconcilePrices(token, primaryPrice, secondaryPrice);
+        if (!primaryAvailable && !secondaryAvailable) {
+            revert Errors.NoOracleData(token);
+        }
+
+        if (primaryAvailable && secondaryAvailable) {
+            OracleUtils.ValidatedPrice memory primaryPrice = primary.getOraclePrice(
+                token,
+                primaryData
+            );
+            OracleUtils.ValidatedPrice memory secondaryPrice = secondary.getOraclePrice(
+                token,
+                secondaryData
+            );
+            return _reconcilePrices(token, primaryPrice, secondaryPrice);
+        }
+
+        // Degraded mode: exactly one feed present.
+        if (!dataStore.getBool(Keys.allowSingleOracleFallbackKey(token))) {
+            revert Errors.OracleSingleFallbackDisabled(token);
+        }
+
+        OracleUtils.ValidatedPrice memory single;
+        if (primaryAvailable) {
+            single = primary.getOraclePrice(token, primaryData);
+            emit OracleDegradedMode(token, false);
+        } else {
+            single = secondary.getOraclePrice(token, secondaryData);
+            emit OracleDegradedMode(token, true);
+        }
+
+        // Re-attribute so downstream provider-based logic sees the wrapper uniformly.
+        single.provider = address(this);
+        return single;
     }
 
     // @dev Reconciliation policy:


### PR DESCRIPTION
## Summary

Adds `CircuitBreakerOracleProvider` — a composite `IOracleProvider` that wraps two
underlying oracle providers (primary + secondary, e.g. Pyth Lazer + Chainlink Data
Streams) and runs in **hybrid mode**: circuit breaker when both feeds are available,
graceful fallback to a single feed when one is down.

Per-token swap-in via the existing `Keys.oracleProviderForTokenKey(token)` config —
rollout can happen one market at a time (recommended: BTC/ETH first, where
manipulation risk is highest and liquidity makes tight thresholds feasible).

## Behavior (three modes, selected per-call by keeper payload)

| Keeper sends                              | Wrapper behavior                                                      |
| :---------------------------------------- | :-------------------------------------------------------------------- |
| Both `primaryData` + `secondaryData`      | Deviation + timestamp-skew checks; revert if either fails. On pass, return defensive pair (wider min/max, older timestamp). |
| Only one side (other is empty bytes)      | Serve that feed directly if `allowSingleOracleFallback[token] = true`, else revert with `OracleSingleFallbackDisabled`. Emits `OracleDegradedMode`. |
| Both empty                                | Revert with `NoOracleData`.                                           |

Keeper signals "feed unavailable" by sending zero-length bytes on that side — no
special encoding, just an empty `bytes`.

## Reconciliation policy (when both feeds present)

1. **Timestamp skew**: reject if `|primary.ts − secondary.ts| > Keys.circuitBreakerTimestampSkewKey(token)`
   seconds (default 5s if unset).
2. **Deviation**: reject if midpoint-vs-midpoint deviation exceeds
   `Keys.circuitBreakerDeviationBpsKey(token)`.
   **Required per-token** — reverts with `EmptyCircuitBreakerDeviationBps` if unset.
   (Intentional: forgetting this value would silently disable the circuit breaker.)
3. **Defensive return**: on acceptance, returns `min(primary.min, secondary.min)`,
   `max(primary.max, secondary.max)`, with the **older** of the two timestamps so
   downstream staleness checks catch a pair where one feed has drifted behind.

## Fallback policy (when one feed present)

- **Opt-in per market** via `Keys.allowSingleOracleFallbackKey(token)`, default
  `false`. Governance chooses which markets can tolerate single-oracle operation
  during an outage vs. which should halt trading until both feeds return.
- When fallback triggers, `OracleDegradedMode(token, usedSecondary)` is emitted.
  Wire this to monitoring — frequent fires mean that market is effectively
  single-oracle and you've lost circuit-breaker protection.
- The served price has `provider = address(this)` (the wrapper), not the
  underlying feed, so downstream provider-based logic stays consistent.

## Changes

- `contracts/oracle/CircuitBreakerOracleProvider.sol` — new composite provider
- `contracts/oracle/ChainlinkDataStreamProvider.sol` — `onlyOracle` modifier now
  also accepts addresses flagged via `Keys.isDataStreamAuthorizedCallerKey(caller)`.
  Lets the wrapper delegate without replacing the Oracle contract as sole caller.
- `contracts/data/Keys.sol` — 4 new constants + 4 per-token helpers
  (`circuitBreakerDeviationBpsKey`, `circuitBreakerTimestampSkewKey`,
  `isDataStreamAuthorizedCallerKey`, `allowSingleOracleFallbackKey`)
- `contracts/error/Errors.sol` — 5 typed errors with full post-mortem context

## Deployment steps (per-market rollout)

1. Deploy `CircuitBreakerOracleProvider(dataStore, pythLazerProvider, chainlinkDataStreamProvider)`
2. `Config.setBool(IS_DATA_STREAM_AUTHORIZED_CALLER, [wrapperAddr], true)` — authorize wrapper to call Chainlink
3. `Config.setBool(IS_ORACLE_PROVIDER_ENABLED, [wrapperAddr], true)` — enable as oracle provider
4. Per market:
   - `Config.setUint(CIRCUIT_BREAKER_DEVIATION_BPS, [token], <bps>)` — tune per asset (50 bps majors, 100 bps alts recommended)
   - `Config.setUint(CIRCUIT_BREAKER_TIMESTAMP_SKEW, [token], 5)` — optional, defaults to 5s
   - `Config.setBool(ALLOW_SINGLE_ORACLE_FALLBACK, [token], <bool>)` — opt-in for availability-over-strictness markets
5. `Config.setAddress(ORACLE_PROVIDER_FOR_TOKEN, [token], wrapperAddr)` — flip market
6. **Wait on keeper-side Chainlink Data Streams subscription** before step 5 (see companion PR)

## Dependencies

- Keeper change: `taoshidev/unified-executor#6`
- **Blocked on**: Chainlink Data Streams subscription/caching module in `unified-executor` (equivalent of `pythLazer.ts`). Not yet built. This PR can merge independently, but per-token rollout requires that module first.

## Risk notes

- Contract is new, composite, and hot-path — needs audit before mainnet rollout.
- Fallback default is `false` (fail-closed). If a keeper bug suddenly sends empty
  `secondaryData` on all trades, markets halt rather than silently downgrading.
- Trade gas cost increases ~2x on the oracle portion when both feeds are present
  (two `verify()` calls, ~2x calldata). Acceptable for derivatives; may be too
  expensive for high-frequency swap flows.

## Test plan

- [x] `npx hardhat compile` passes clean
- [ ] Unit: reject on timestamp skew > threshold
- [ ] Unit: reject on deviation > threshold
- [ ] Unit: reject when `CIRCUIT_BREAKER_DEVIATION_BPS` unset
- [ ] Unit: accept within tolerance — verify defensive min/max + older timestamp
- [ ] Unit: fallback disabled → `OracleSingleFallbackDisabled` revert
- [ ] Unit: fallback enabled, primary empty → returns secondary, emits event, provider re-attributed
- [ ] Unit: fallback enabled, secondary empty → returns primary, emits event
- [ ] Unit: both empty → `NoOracleData` revert
- [ ] Unit: `isDataStreamAuthorizedCallerKey` allowlist path — wrapper authorized, direct Oracle caller still works, random address still reverts
- [ ] Integration: full trade path with one market flipped to wrapper, monitor `OracleDegradedMode` events
