### PR TITLE
Liquidation fee split 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out
 /cache/
 artifacts
 deployments/localhost
+deployments/baseSepoliaFork
 deployments.txt
 *.log
 .cursorignore*

--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -408,6 +408,9 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
     // @dev initialize the allowed base keys
     function _initAllowedBaseKeys() internal {
         allowedBaseKeys[Keys.HOLDING_ADDRESS] = true;
+        allowedBaseKeys[Keys.INSURANCE_FUND_ADDRESS] = true;
+        allowedBaseKeys[Keys.VALIDATOR_FEE_RECEIVER] = true;
+        allowedBaseKeys[Keys.BUYBACK_FEE_RECEIVER] = true;
 
         allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS] = true;
         allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS_TO_FORWARD] = true;
@@ -480,6 +483,9 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         allowedBaseKeys[Keys.POSITION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
         allowedBaseKeys[Keys.LIQUIDATION_FEE_RECEIVER_FACTOR] = true;
         allowedBaseKeys[Keys.LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_INSURANCE_FACTOR] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_BUYBACK_FACTOR] = true;
         allowedBaseKeys[Keys.SWAP_FEE_RECEIVER_FACTOR] = true;
         allowedBaseKeys[Keys.SWAP_FEE_SECONDARY_RECEIVER_FACTOR] = true;
         allowedBaseKeys[Keys.BORROWING_FEE_RECEIVER_FACTOR] = true;
@@ -764,6 +770,9 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
             baseKey == Keys.SWAP_FEE_RECEIVER_FACTOR ||
             baseKey == Keys.BORROWING_FEE_RECEIVER_FACTOR ||
             baseKey == Keys.LIQUIDATION_FEE_RECEIVER_FACTOR ||
+            baseKey == Keys.LIQUIDATION_FEE_INSURANCE_FACTOR ||
+            baseKey == Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR ||
+            baseKey == Keys.LIQUIDATION_FEE_BUYBACK_FACTOR ||
             baseKey == Keys.MAX_PNL_FACTOR ||
             baseKey == Keys.MIN_PNL_FACTOR_AFTER_ADL ||
             baseKey == Keys.OPTIMAL_USAGE_FACTOR ||

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -16,6 +16,14 @@ library Keys {
     bytes32 public constant FEE_RECEIVER = keccak256(abi.encode("FEE_RECEIVER"));
     bytes32 public constant SECONDARY_FEE_RECEIVER = keccak256(abi.encode("SECONDARY_FEE_RECEIVER"));
 
+    // @dev address of the insurance fund — receives a share of liquidation fees
+    // and acts as last-resort backstop for insolvent-close shortfalls.
+    bytes32 public constant INSURANCE_FUND_ADDRESS = keccak256(abi.encode("INSURANCE_FUND_ADDRESS"));
+    // @dev address that accumulates the validator share of liquidation fees
+    bytes32 public constant VALIDATOR_FEE_RECEIVER = keccak256(abi.encode("VALIDATOR_FEE_RECEIVER"));
+    // @dev address that accumulates the alpha-buyback share of liquidation
+    bytes32 public constant BUYBACK_FEE_RECEIVER = keccak256(abi.encode("BUYBACK_FEE_RECEIVER"));
+
     // @dev for holding tokens that could not be sent out
     bytes32 public constant HOLDING_ADDRESS = keccak256(abi.encode("HOLDING_ADDRESS"));
 
@@ -207,6 +215,12 @@ library Keys {
     // @dev key for the percentage amount of liquidation fees to be received
     bytes32 public constant LIQUIDATION_FEE_RECEIVER_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_RECEIVER_FACTOR"));
     bytes32 public constant LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR"));
+    // @dev key for the share of liquidation fees routed to the insurance fund
+    bytes32 public constant LIQUIDATION_FEE_INSURANCE_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_INSURANCE_FACTOR"));
+    // @dev key for the share of liquidation fees routed to the validator pool
+    bytes32 public constant LIQUIDATION_FEE_VALIDATOR_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_VALIDATOR_FACTOR"));
+    // @dev key for the share of liquidation fees routed to alpha buyback
+    bytes32 public constant LIQUIDATION_FEE_BUYBACK_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_BUYBACK_FACTOR"));
     // @dev key for the percentage amount of swap fees to be received
     bytes32 public constant SWAP_FEE_RECEIVER_FACTOR = keccak256(abi.encode("SWAP_FEE_RECEIVER_FACTOR"));
     bytes32 public constant SWAP_FEE_SECONDARY_RECEIVER_FACTOR = keccak256(abi.encode("SWAP_FEE_SECONDARY_RECEIVER_FACTOR"));

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -346,6 +346,8 @@ library DecreasePositionCollateralUtils {
                 );
             }
 
+            _distributeLiquidationShares(params, fees, collateralToken);
+
             FeeUtils.incrementClaimableUiFeeAmount(
                 params.contracts.dataStore,
                 params.contracts.eventEmitter,
@@ -634,6 +636,52 @@ library DecreasePositionCollateralUtils {
         return (values, getEmptyFees(fees));
     }
 
+    // @dev distributes the insurance / validator / buyback shares of a liquidation fee.
+    function _distributeLiquidationShares(
+        PositionUtils.UpdatePositionParams memory params,
+        PositionPricingUtils.PositionFees memory fees,
+        address collateralToken
+    ) internal {
+        address insuranceFundAddress = params.contracts.dataStore.getAddress(Keys.INSURANCE_FUND_ADDRESS);
+        if (insuranceFundAddress != address(0)) {
+            FeeUtils.incrementClaimableFeeAmount(
+                params.contracts.dataStore,
+                params.contracts.eventEmitter,
+                insuranceFundAddress,
+                params.market.marketToken,
+                collateralToken,
+                fees.insuranceFeeAmount,
+                Keys.POSITION_FEE_TYPE
+            );
+        }
+
+        address validatorFeeReceiver = params.contracts.dataStore.getAddress(Keys.VALIDATOR_FEE_RECEIVER);
+        if (validatorFeeReceiver != address(0)) {
+            FeeUtils.incrementClaimableFeeAmount(
+                params.contracts.dataStore,
+                params.contracts.eventEmitter,
+                validatorFeeReceiver,
+                params.market.marketToken,
+                collateralToken,
+                fees.validatorFeeAmount,
+                Keys.POSITION_FEE_TYPE
+            );
+        }
+
+        address buybackFeeReceiver = params.contracts.dataStore.getAddress(Keys.BUYBACK_FEE_RECEIVER);
+        if (buybackFeeReceiver != address(0)) {
+            FeeUtils.incrementClaimableFeeAmount(
+                params.contracts.dataStore,
+                params.contracts.eventEmitter,
+                buybackFeeReceiver,
+                params.market.marketToken,
+                collateralToken,
+                fees.buybackFeeAmount,
+                Keys.POSITION_FEE_TYPE
+            );
+        }
+    }
+
     function getEmptyFees(
         PositionPricingUtils.PositionFees memory fees
     ) internal pure returns (PositionPricingUtils.PositionFees memory) {
@@ -690,7 +738,13 @@ library DecreasePositionCollateralUtils {
             liquidationFeeReceiverFactor: 0,
             liquidationFeeAmountForFeeReceiver: 0,
             liquidationFeeSecondaryReceiverFactor: 0,
-            liquidationFeeAmountForSecondaryReceiver: 0
+            liquidationFeeAmountForSecondaryReceiver: 0,
+            liquidationFeeInsuranceFactor: 0,
+            liquidationFeeAmountForInsurance: 0,
+            liquidationFeeValidatorFactor: 0,
+            liquidationFeeAmountForValidator: 0,
+            liquidationFeeBuybackFactor: 0,
+            liquidationFeeAmountForBuyback: 0
         });
 
         // all fees are zeroed even though funding may have been paid
@@ -709,6 +763,9 @@ library DecreasePositionCollateralUtils {
             positionFeeSecondaryReceiverFactor: 0,
             feeReceiverAmount: 0,
             secondaryFeeReceiverAmount: 0,
+            insuranceFeeAmount: 0,
+            validatorFeeAmount: 0,
+            buybackFeeAmount: 0,
             feeAmountForPool: 0,
             positionFeeAmountForPool: 0,
             positionFeeAmount: 0,

--- a/contracts/pricing/PositionPricingUtils.sol
+++ b/contracts/pricing/PositionPricingUtils.sol
@@ -91,6 +91,9 @@ library PositionPricingUtils {
         uint256 positionFeeSecondaryReceiverFactor;
         uint256 feeReceiverAmount;
         uint256 secondaryFeeReceiverAmount;
+        uint256 insuranceFeeAmount;
+        uint256 validatorFeeAmount;
+        uint256 buybackFeeAmount;
         uint256 feeAmountForPool;
         uint256 positionFeeAmountForPool;
         uint256 positionFeeAmount;
@@ -112,6 +115,15 @@ library PositionPricingUtils {
         uint256 liquidationFeeAmountForFeeReceiver;
         uint256 liquidationFeeSecondaryReceiverFactor;
         uint256 liquidationFeeAmountForSecondaryReceiver;
+        // 4-way split extension: per-share factors + amounts. Any share whose
+        // address is unset (address(0)) or factor is zero is skipped; the
+        // remainder accrues to the LP pool as before.
+        uint256 liquidationFeeInsuranceFactor;
+        uint256 liquidationFeeAmountForInsurance;
+        uint256 liquidationFeeValidatorFactor;
+        uint256 liquidationFeeAmountForValidator;
+        uint256 liquidationFeeBuybackFactor;
+        uint256 liquidationFeeAmountForBuyback;
     }
 
     // @param affiliate the referral affiliate of the trader
@@ -320,9 +332,15 @@ library PositionPricingUtils {
     // @param shortToken the short token of the market
     // @param sizeDeltaUsd the change in position size
     // @return PositionFees
+    // Marked `public` (was `internal`) to force PositionUtils to call this via
+    // DELEGATECALL rather than inline it. After the liquidation 4-way split
+    // expanded PositionFees / PositionLiquidationFees, the optimizer started
+    // inlining the whole call into PositionUtils — pushing its bytecode past
+    // EIP-170's 24576-byte deploy limit. Public preserves the library
+    // boundary and keeps PositionUtils deployable.
     function getPositionFees(
         GetPositionFeesParams memory params
-    ) internal view returns (PositionFees memory) {
+    ) public view returns (PositionFees memory) {
         PositionFees memory fees = getPositionFeesAfterReferral(
             params.dataStore,
             params.referralStorage,
@@ -352,7 +370,10 @@ library PositionPricingUtils {
             fees.borrowing.borrowingFeeAmountForSecondaryReceiver +
             fees.liquidation.liquidationFeeAmount -
             fees.liquidation.liquidationFeeAmountForSecondaryReceiver -
-            fees.liquidation.liquidationFeeAmountForFeeReceiver;
+            fees.liquidation.liquidationFeeAmountForFeeReceiver -
+            fees.liquidation.liquidationFeeAmountForInsurance -
+            fees.liquidation.liquidationFeeAmountForValidator -
+            fees.liquidation.liquidationFeeAmountForBuyback;
 
         fees.feeReceiverAmount +=
             fees.borrowing.borrowingFeeAmountForFeeReceiver +
@@ -361,6 +382,13 @@ library PositionPricingUtils {
         fees.secondaryFeeReceiverAmount +=
             fees.borrowing.borrowingFeeAmountForSecondaryReceiver +
             fees.liquidation.liquidationFeeAmountForSecondaryReceiver;
+
+        // The 4-way split goes through its own dedicated receivers; not folded
+        // into feeReceiverAmount / secondaryFeeReceiverAmount because those are
+        // shared with non-liquidation flows (positionFee, borrowingFee).
+        fees.insuranceFeeAmount = fees.liquidation.liquidationFeeAmountForInsurance;
+        fees.validatorFeeAmount = fees.liquidation.liquidationFeeAmountForValidator;
+        fees.buybackFeeAmount = fees.liquidation.liquidationFeeAmountForBuyback;
 
         fees.funding.latestFundingFeeAmountPerSize = MarketUtils.getFundingFeeAmountPerSize(
             params.dataStore,
@@ -597,6 +625,16 @@ library PositionPricingUtils {
         liquidationFees.liquidationFeeAmountForFeeReceiver = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeReceiverFactor);
         liquidationFees.liquidationFeeSecondaryReceiverFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR);
         liquidationFees.liquidationFeeAmountForSecondaryReceiver = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeSecondaryReceiverFactor);
+        // 4-way split: insurance / validator / buyback. Pool gets the remainder
+        // (computed in getPositionFees below). Caller-side responsibility: sum
+        // of all five factors must be <= FLOAT_PRECISION (100%); enforced by
+        // Config.sol range checks at write time, not validated again here.
+        liquidationFees.liquidationFeeInsuranceFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_INSURANCE_FACTOR);
+        liquidationFees.liquidationFeeAmountForInsurance = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeInsuranceFactor);
+        liquidationFees.liquidationFeeValidatorFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR);
+        liquidationFees.liquidationFeeAmountForValidator = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeValidatorFactor);
+        liquidationFees.liquidationFeeBuybackFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_BUYBACK_FACTOR);
+        liquidationFees.liquidationFeeAmountForBuyback = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeBuybackFactor);
         return liquidationFees;
     }
 }

--- a/contracts/pricing/PositionPricingUtils.sol
+++ b/contracts/pricing/PositionPricingUtils.sol
@@ -115,9 +115,6 @@ library PositionPricingUtils {
         uint256 liquidationFeeAmountForFeeReceiver;
         uint256 liquidationFeeSecondaryReceiverFactor;
         uint256 liquidationFeeAmountForSecondaryReceiver;
-        // 4-way split extension: per-share factors + amounts. Any share whose
-        // address is unset (address(0)) or factor is zero is skipped; the
-        // remainder accrues to the LP pool as before.
         uint256 liquidationFeeInsuranceFactor;
         uint256 liquidationFeeAmountForInsurance;
         uint256 liquidationFeeValidatorFactor;
@@ -332,12 +329,6 @@ library PositionPricingUtils {
     // @param shortToken the short token of the market
     // @param sizeDeltaUsd the change in position size
     // @return PositionFees
-    // Marked `public` (was `internal`) to force PositionUtils to call this via
-    // DELEGATECALL rather than inline it. After the liquidation 4-way split
-    // expanded PositionFees / PositionLiquidationFees, the optimizer started
-    // inlining the whole call into PositionUtils — pushing its bytecode past
-    // EIP-170's 24576-byte deploy limit. Public preserves the library
-    // boundary and keeps PositionUtils deployable.
     function getPositionFees(
         GetPositionFeesParams memory params
     ) public view returns (PositionFees memory) {
@@ -383,9 +374,6 @@ library PositionPricingUtils {
             fees.borrowing.borrowingFeeAmountForSecondaryReceiver +
             fees.liquidation.liquidationFeeAmountForSecondaryReceiver;
 
-        // The 4-way split goes through its own dedicated receivers; not folded
-        // into feeReceiverAmount / secondaryFeeReceiverAmount because those are
-        // shared with non-liquidation flows (positionFee, borrowingFee).
         fees.insuranceFeeAmount = fees.liquidation.liquidationFeeAmountForInsurance;
         fees.validatorFeeAmount = fees.liquidation.liquidationFeeAmountForValidator;
         fees.buybackFeeAmount = fees.liquidation.liquidationFeeAmountForBuyback;
@@ -625,10 +613,6 @@ library PositionPricingUtils {
         liquidationFees.liquidationFeeAmountForFeeReceiver = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeReceiverFactor);
         liquidationFees.liquidationFeeSecondaryReceiverFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR);
         liquidationFees.liquidationFeeAmountForSecondaryReceiver = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeSecondaryReceiverFactor);
-        // 4-way split: insurance / validator / buyback. Pool gets the remainder
-        // (computed in getPositionFees below). Caller-side responsibility: sum
-        // of all five factors must be <= FLOAT_PRECISION (100%); enforced by
-        // Config.sol range checks at write time, not validated again here.
         liquidationFees.liquidationFeeInsuranceFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_INSURANCE_FACTOR);
         liquidationFees.liquidationFeeAmountForInsurance = Precision.applyFactor(liquidationFees.liquidationFeeAmount, liquidationFees.liquidationFeeInsuranceFactor);
         liquidationFees.liquidationFeeValidatorFactor = dataStore.getUint(Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR);

--- a/deploy/configureRoles.ts
+++ b/deploy/configureRoles.ts
@@ -13,6 +13,7 @@ import { grantRoleIfNotGranted, revokeRoleIfGranted } from "../utils/role";
 const rolesToRemove = {
   base: [],
   baseSepolia: [],
+  baseSepoliaFork: [],
   hardhat: [],
   localhost: [],
 };

--- a/deploy/deployDecreasePositionCollateralUtils.ts
+++ b/deploy/deployDecreasePositionCollateralUtils.ts
@@ -3,15 +3,13 @@ import { createDeployFunction } from "../utils/deploy";
 const func = createDeployFunction({
   contractName: "DecreasePositionCollateralUtils",
   libraryNames: [
-    "BaseOrderUtils",
-    "FeeUtils",
-    "MarketCollateralUtils",
-    "MarketEventUtils",
-    "PositionUtils",
-    "PositionPricingUtils",
-    "PositionEventUtils",
-    "OrderEventUtils",
     "DecreasePositionSwapUtils",
+    "FeeUtils",
+    "MarketEventUtils",
+    "OrderEventUtils",
+    "PositionEventUtils",
+    "PositionPricingUtils",
+    "PositionUtils",
   ],
 });
 

--- a/deploy/deployDecreasePositionUtils.ts
+++ b/deploy/deployDecreasePositionUtils.ts
@@ -3,17 +3,15 @@ import { createDeployFunction } from "../utils/deploy";
 const func = createDeployFunction({
   contractName: "DecreasePositionUtils",
   libraryNames: [
-    "MarketCollateralUtils",
-    "MarketUtils",
-    "MarketEventUtils",
-    "PositionUtils",
-    "PositionStoreUtils",
-    "PositionEventUtils",
-    "OrderEventUtils",
-    "PositionPricingUtils",
-    "ReferralEventUtils",
     "DecreasePositionCollateralUtils",
     "DecreasePositionSwapUtils",
+    "MarketEventUtils",
+    "MarketUtils",
+    "OrderEventUtils",
+    "PositionEventUtils",
+    "PositionStoreUtils",
+    "PositionUtils",
+    "ReferralEventUtils",
   ],
 });
 

--- a/deploy/deployIncreasePositionUtils.ts
+++ b/deploy/deployIncreasePositionUtils.ts
@@ -4,12 +4,12 @@ const func = createDeployFunction({
   contractName: "IncreasePositionUtils",
   libraryNames: [
     "FeeUtils",
-    "MarketCollateralUtils",
-    "MarketUtils",
     "MarketEventUtils",
-    "PositionUtils",
-    "PositionStoreUtils",
+    "MarketUtils",
     "PositionEventUtils",
+    "PositionPricingUtils",
+    "PositionStoreUtils",
+    "PositionUtils",
     "ReferralEventUtils",
   ],
 });

--- a/deploy/deployReaderPositionUtils.ts
+++ b/deploy/deployReaderPositionUtils.ts
@@ -2,7 +2,14 @@ import { createDeployFunction } from "../utils/deploy";
 
 const func = createDeployFunction({
   contractName: "ReaderPositionUtils",
-  libraryNames: ["MarketUtils", "MarketStoreUtils", "PositionStoreUtils", "PositionUtils", "ReaderPricingUtils"],
+  libraryNames: [
+    "MarketUtils",
+    "MarketStoreUtils",
+    "PositionStoreUtils",
+    "PositionUtils",
+    "PositionPricingUtils",
+    "ReaderPricingUtils",
+  ],
 });
 
 export default func;

--- a/scripts/updateGeneralConfigUtils.ts
+++ b/scripts/updateGeneralConfigUtils.ts
@@ -147,6 +147,34 @@ const processGeneralConfig = async ({ generalConfig, oracleConfig, handleConfig 
     );
   }
 
+  if (generalConfig.liquidationFeeInsuranceFactor !== undefined) {
+    await handleConfig(
+      "uint",
+      keys.LIQUIDATION_FEE_INSURANCE_FACTOR,
+      "0x",
+      generalConfig.liquidationFeeInsuranceFactor,
+      `liquidationFeeInsuranceFactor`
+    );
+  }
+  if (generalConfig.liquidationFeeValidatorFactor !== undefined) {
+    await handleConfig(
+      "uint",
+      keys.LIQUIDATION_FEE_VALIDATOR_FACTOR,
+      "0x",
+      generalConfig.liquidationFeeValidatorFactor,
+      `liquidationFeeValidatorFactor`
+    );
+  }
+  if (generalConfig.liquidationFeeBuybackFactor !== undefined) {
+    await handleConfig(
+      "uint",
+      keys.LIQUIDATION_FEE_BUYBACK_FACTOR,
+      "0x",
+      generalConfig.liquidationFeeBuybackFactor,
+      `liquidationFeeBuybackFactor`
+    );
+  }
+
   await handleConfig("uint", keys.DEPOSIT_GAS_LIMIT, "0x", generalConfig.depositGasLimit, `depositGasLimit`);
 
   await handleConfig("uint", keys.WITHDRAWAL_GAS_LIMIT, "0x", generalConfig.withdrawalGasLimit, `withdrawalGasLimit`);

--- a/test/exchange/LiquidationFeeSplit.ts
+++ b/test/exchange/LiquidationFeeSplit.ts
@@ -1,0 +1,147 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { deployFixture } from "../../utils/fixture";
+import { expandDecimals, decimalToFloat } from "../../utils/math";
+import { handleDeposit } from "../../utils/deposit";
+import { OrderType, handleOrder } from "../../utils/order";
+import { executeLiquidation } from "../../utils/liquidation";
+import { grantRole } from "../../utils/role";
+import { getClaimableFeeAmount } from "../../utils/fee";
+import * as keys from "../../utils/keys";
+
+describe("Exchange.LiquidationFeeSplit", () => {
+  let fixture;
+  let wallet, user0;
+  let roleStore, dataStore, ethUsdMarket, wnt, usdc;
+  let insuranceFund, validatorReceiver, buybackReceiver;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ wallet, user0 } = fixture.accounts);
+    ({ roleStore, dataStore, ethUsdMarket, wnt, usdc } = fixture.contracts);
+
+    [insuranceFund, validatorReceiver, buybackReceiver] = (await ethers.getSigners()).slice(-3);
+
+    await dataStore.setAddress(keys.INSURANCE_FUND_ADDRESS, insuranceFund.address);
+    await dataStore.setAddress(keys.VALIDATOR_FEE_RECEIVER, validatorReceiver.address);
+    await dataStore.setAddress(keys.BUYBACK_FEE_RECEIVER, buybackReceiver.address);
+    await dataStore.setUint(keys.LIQUIDATION_FEE_RECEIVER_FACTOR, decimalToFloat(5, 2)); // 5%
+    await dataStore.setUint(keys.LIQUIDATION_FEE_INSURANCE_FACTOR, decimalToFloat(5, 1)); // 50%
+    await dataStore.setUint(keys.LIQUIDATION_FEE_VALIDATOR_FACTOR, decimalToFloat(2, 1)); // 20%
+    await dataStore.setUint(keys.LIQUIDATION_FEE_BUYBACK_FACTOR, decimalToFloat(2, 1)); // 20%
+
+    // Liquidation fee = 0.5% of size in USD (matches Hardhat fixture default).
+    await dataStore.setUint(keys.liquidationFeeFactorKey(ethUsdMarket.marketToken), decimalToFloat(5, 3));
+
+    await handleDeposit(fixture, {
+      create: { market: ethUsdMarket, longTokenAmount: expandDecimals(1000, 18) },
+    });
+
+    await grantRole(roleStore, wallet.address, "LIQUIDATION_KEEPER");
+  });
+
+  it("splits the liquidation fee across insurance / validator / buyback in proportion", async () => {
+    await handleOrder(fixture, {
+      create: {
+        market: ethUsdMarket,
+        initialCollateralToken: wnt,
+        initialCollateralDeltaAmount: expandDecimals(10, 18),
+        sizeDeltaUsd: decimalToFloat(200 * 1000),
+        acceptablePrice: expandDecimals(5001, 12),
+        orderType: OrderType.MarketIncrease,
+        isLong: true,
+      },
+      execute: { tokens: [wnt.address, usdc.address] },
+    });
+
+    await executeLiquidation(fixture, {
+      account: user0.address,
+      market: ethUsdMarket,
+      collateralToken: wnt,
+      isLong: true,
+      minPrices: [expandDecimals(4030, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(4030, 4), expandDecimals(1, 6)],
+      gasUsageLabel: "liquidationHandler.executeLiquidation.4way",
+    });
+
+    const insuranceClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      insuranceFund.address
+    );
+    const validatorClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      validatorReceiver.address
+    );
+    const buybackClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      buybackReceiver.address
+    );
+
+    // All three new receivers received non-zero balances.
+    expect(insuranceClaim).to.be.gt(0);
+    expect(validatorClaim).to.be.gt(0);
+    expect(buybackClaim).to.be.gt(0);
+
+    expect(validatorClaim).to.eq(buybackClaim);
+
+    expect(insuranceClaim).to.eq(validatorClaim.mul(5).div(2));
+  });
+
+  it("skips a share when its receiver address is unset", async () => {
+    await dataStore.setAddress(keys.VALIDATOR_FEE_RECEIVER, ethers.constants.AddressZero);
+
+    await handleOrder(fixture, {
+      create: {
+        market: ethUsdMarket,
+        initialCollateralToken: wnt,
+        initialCollateralDeltaAmount: expandDecimals(10, 18),
+        sizeDeltaUsd: decimalToFloat(200 * 1000),
+        acceptablePrice: expandDecimals(5001, 12),
+        orderType: OrderType.MarketIncrease,
+        isLong: true,
+      },
+      execute: { tokens: [wnt.address, usdc.address] },
+    });
+
+    await executeLiquidation(fixture, {
+      account: user0.address,
+      market: ethUsdMarket,
+      collateralToken: wnt,
+      isLong: true,
+      minPrices: [expandDecimals(4030, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(4030, 4), expandDecimals(1, 6)],
+      gasUsageLabel: "liquidationHandler.executeLiquidation.zeroValidator",
+    });
+
+    const validatorClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      validatorReceiver.address
+    );
+    const insuranceClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      insuranceFund.address
+    );
+    const buybackClaim = await getClaimableFeeAmount(
+      dataStore,
+      ethUsdMarket.marketToken,
+      wnt.address,
+      buybackReceiver.address
+    );
+
+    expect(validatorClaim).to.eq(0);
+    // Insurance and buyback still accrued normally.
+    expect(insuranceClaim).to.be.gt(0);
+    expect(buybackClaim).to.be.gt(0);
+  });
+});

--- a/utils/fee.ts
+++ b/utils/fee.ts
@@ -1,6 +1,6 @@
 import * as keys from "./keys";
 
-export function getClaimableFeeAmount(dataStore, market, token) {
-  const key = keys.claimableFeeAmountKey(market, token);
+export function getClaimableFeeAmount(dataStore, market, token, receiver?: string) {
+  const key = keys.claimableFeeAmountKey(market, token, receiver);
   return dataStore.getUint(key);
 }

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -153,6 +153,12 @@ export const POSITION_FEE_RECEIVER_FACTOR = hashString("POSITION_FEE_RECEIVER_FA
 export const POSITION_FEE_SECONDARY_RECEIVER_FACTOR = hashString("POSITION_FEE_SECONDARY_RECEIVER_FACTOR");
 export const LIQUIDATION_FEE_RECEIVER_FACTOR = hashString("LIQUIDATION_FEE_RECEIVER_FACTOR");
 export const LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR = hashString("LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR");
+export const LIQUIDATION_FEE_INSURANCE_FACTOR = hashString("LIQUIDATION_FEE_INSURANCE_FACTOR");
+export const LIQUIDATION_FEE_VALIDATOR_FACTOR = hashString("LIQUIDATION_FEE_VALIDATOR_FACTOR");
+export const LIQUIDATION_FEE_BUYBACK_FACTOR = hashString("LIQUIDATION_FEE_BUYBACK_FACTOR");
+export const INSURANCE_FUND_ADDRESS = hashString("INSURANCE_FUND_ADDRESS");
+export const VALIDATOR_FEE_RECEIVER = hashString("VALIDATOR_FEE_RECEIVER");
+export const BUYBACK_FEE_RECEIVER = hashString("BUYBACK_FEE_RECEIVER");
 export const BORROWING_FEE_RECEIVER_FACTOR = hashString("BORROWING_FEE_RECEIVER_FACTOR");
 export const BORROWING_FEE_SECONDARY_RECEIVER_FACTOR = hashString("BORROWING_FEE_SECONDARY_RECEIVER_FACTOR");
 
@@ -353,8 +359,11 @@ export function cancelOrderFeatureDisabledKey(contract, orderType) {
   return hashData(["bytes32", "address", "uint256"], [CANCEL_ORDER_FEATURE_DISABLED, contract, orderType]);
 }
 
-export function claimableFeeAmountKey(market: string, token: string) {
-  return hashData(["bytes32", "address", "address"], [CLAIMABLE_FEE_AMOUNT, market, token]);
+export function claimableFeeAmountKey(market: string, token: string, receiver?: string) {
+  if (receiver === undefined) {
+    return hashData(["bytes32", "address", "address"], [CLAIMABLE_FEE_AMOUNT, market, token]);
+  }
+  return hashData(["bytes32", "address", "address", "address"], [CLAIMABLE_FEE_AMOUNT, market, token, receiver]);
 }
 
 export function claimableFundingAmountKey(market: string, token: string, account: string) {


### PR DESCRIPTION
Routes a configurable share of each liquidation fee to three new DataStore-keyed receivers, insurance fund, validator pool, ALPHA buyback etc, alongside the existing FEE_RECEIVER / SECONDARY_FEE_RECEIVER, with the LP pool absorbing whatever remains.