### PR TITLE
refactor(config): split Config into ConfigAllowedKeys + ConfigValidat…

### DIFF
--- a/contracts/config/Config.sol
+++ b/contracts/config/Config.sol
@@ -12,6 +12,8 @@ import "../utils/BasicMulticall.sol";
 import "../utils/Precision.sol";
 import "../utils/Cast.sol";
 import "../market/MarketUtils.sol";
+import "./ConfigAllowedKeys.sol";
+import "./ConfigValidatorUtils.sol";
 
 // @title Config
 contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
@@ -25,15 +27,6 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
 
     uint256 public constant MAX_FEE_FACTOR = (5 * Precision.FLOAT_PRECISION) / 100; // 5%
 
-    // 0.00001% per second, ~315% per year
-    uint256 public constant MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND = 100000000000000000000000;
-    // at this rate max allowed funding rate will be reached in 1 hour at 100% imbalance if max funding rate is 315%
-    uint256 public constant MAX_ALLOWED_FUNDING_INCREASE_FACTOR_PER_SECOND =
-        MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND / 1 hours;
-    // at this rate zero funding rate will be reached in 24 hours if max funding rate is 315%
-    uint256 public constant MAX_ALLOWED_FUNDING_DECREASE_FACTOR_PER_SECOND =
-        MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND / 24 hours;
-
     DataStore public immutable dataStore;
     EventEmitter public immutable eventEmitter;
 
@@ -46,7 +39,7 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         dataStore = _dataStore;
         eventEmitter = _eventEmitter;
 
-        _initAllowedBaseKeys();
+        ConfigAllowedKeys.initAllowedBaseKeys(allowedBaseKeys);
         // _initAllowedLimitedBaseKeys();
     }
 
@@ -113,7 +106,12 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
             revert Errors.DataStreamIdAlreadyExistsForToken(token);
         }
 
-        _validateRange(Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR, abi.encode(token), dataStreamSpreadReductionFactor);
+        ConfigValidatorUtils.validateRange(
+            dataStore,
+            Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR,
+            abi.encode(token),
+            dataStreamSpreadReductionFactor
+        );
 
         dataStore.setBytes32(Keys.dataStreamIdKey(token), feedId);
         dataStore.setBool(Keys.dataStreamInvertedKey(token), dataStreamInverted);
@@ -362,7 +360,7 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
 
         bytes32 fullKey = Keys.getFullKey(baseKey, data);
 
-        _validateRange(baseKey, data, value);
+        ConfigValidatorUtils.validateRange(dataStore, baseKey, data, value);
 
         dataStore.setUint(fullKey, value);
 
@@ -405,225 +403,6 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         eventEmitter.emitEventLog1("SetInt", baseKey, eventData);
     }
 
-    // @dev initialize the allowed base keys
-    function _initAllowedBaseKeys() internal {
-        allowedBaseKeys[Keys.HOLDING_ADDRESS] = true;
-
-        allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS] = true;
-        allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS_TO_FORWARD] = true;
-        allowedBaseKeys[Keys.MIN_ADDITIONAL_GAS_FOR_EXECUTION] = true;
-
-        allowedBaseKeys[Keys.IS_MARKET_DISABLED] = true;
-
-        allowedBaseKeys[Keys.MAX_SWAP_PATH_LENGTH] = true;
-        allowedBaseKeys[Keys.MAX_CALLBACK_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.REFUND_EXECUTION_FEE_GAS_LIMIT] = true;
-
-        allowedBaseKeys[Keys.MIN_POSITION_SIZE_USD] = true;
-        allowedBaseKeys[Keys.MAX_POSITION_IMPACT_FACTOR_FOR_LIQUIDATIONS] = true;
-
-        allowedBaseKeys[Keys.MAX_POOL_AMOUNT] = true;
-        allowedBaseKeys[Keys.MAX_POOL_USD_FOR_DEPOSIT] = true;
-        allowedBaseKeys[Keys.MAX_OPEN_INTEREST] = true;
-
-        allowedBaseKeys[Keys.MIN_MARKET_TOKENS_FOR_FIRST_DEPOSIT] = true;
-
-        allowedBaseKeys[Keys.CREATE_DEPOSIT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_DEPOSIT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_DEPOSIT_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_WITHDRAWAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_WITHDRAWAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_WITHDRAWAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_ATOMIC_WITHDRAWAL_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_SHIFT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_SHIFT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_SHIFT_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_ORDER_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_ORDER_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_ADL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.UPDATE_ORDER_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_ORDER_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_GLV_DEPOSIT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_GLV_DEPOSIT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_GLV_DEPOSIT_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CANCEL_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CREATE_GLV_SHIFT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.EXECUTE_GLV_SHIFT_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.CLAIM_FUNDING_FEES_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CLAIM_COLLATERAL_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CLAIM_AFFILIATE_REWARDS_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.CLAIM_UI_FEES_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.MIN_AFFILIATE_REWARD_FACTOR] = true;
-
-        allowedBaseKeys[Keys.SUBACCOUNT_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.GASLESS_FEATURE_DISABLED] = true;
-
-        allowedBaseKeys[Keys.MIN_ORACLE_BLOCK_CONFIRMATIONS] = true;
-        allowedBaseKeys[Keys.MAX_ORACLE_PRICE_AGE] = true;
-        allowedBaseKeys[Keys.MAX_ORACLE_TIMESTAMP_RANGE] = true;
-        allowedBaseKeys[Keys.ORACLE_TIMESTAMP_ADJUSTMENT] = true;
-        allowedBaseKeys[Keys.CHAINLINK_PAYMENT_TOKEN] = true;
-        allowedBaseKeys[Keys.SEQUENCER_GRACE_DURATION] = true;
-        allowedBaseKeys[Keys.MAX_ORACLE_REF_PRICE_DEVIATION_FACTOR] = true;
-
-        allowedBaseKeys[Keys.POSITION_FEE_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.POSITION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.LIQUIDATION_FEE_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.SWAP_FEE_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.SWAP_FEE_SECONDARY_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.BORROWING_FEE_RECEIVER_FACTOR] = true;
-        allowedBaseKeys[Keys.BORROWING_FEE_SECONDARY_RECEIVER_FACTOR] = true;
-
-        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1] = true;
-        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_PER_ORACLE_PRICE] = true;
-        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_MULTIPLIER_FACTOR] = true;
-
-        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_BASE_AMOUNT_V2_1] = true;
-        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_PER_ORACLE_PRICE] = true;
-        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_MULTIPLIER_FACTOR] = true;
-
-        allowedBaseKeys[Keys.MAX_EXECUTION_FEE_MULTIPLIER_FACTOR] = true;
-
-        allowedBaseKeys[Keys.DEPOSIT_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.WITHDRAWAL_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.GLV_DEPOSIT_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.GLV_WITHDRAWAL_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.GLV_SHIFT_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.GLV_PER_MARKET_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.SHIFT_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.SINGLE_SWAP_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.INCREASE_ORDER_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.DECREASE_ORDER_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.SWAP_ORDER_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.TOKEN_TRANSFER_GAS_LIMIT] = true;
-        allowedBaseKeys[Keys.NATIVE_TOKEN_TRANSFER_GAS_LIMIT] = true;
-
-        allowedBaseKeys[Keys.REQUEST_EXPIRATION_TIME] = true;
-        allowedBaseKeys[Keys.MAX_LEVERAGE] = true;
-        allowedBaseKeys[Keys.MIN_LEVERAGE] = true;
-        allowedBaseKeys[Keys.MIN_MMR] = true;
-        allowedBaseKeys[Keys.MAX_MMR] = true;
-        allowedBaseKeys[Keys.MMR_TUNING] = true;
-        allowedBaseKeys[Keys.MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER] = true;
-        allowedBaseKeys[Keys.MIN_COLLATERAL_USD] = true;
-
-        allowedBaseKeys[Keys.VIRTUAL_TOKEN_ID] = true;
-        allowedBaseKeys[Keys.VIRTUAL_MARKET_ID] = true;
-        allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_SWAPS] = true;
-        allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_POSITIONS] = true;
-
-        allowedBaseKeys[Keys.POSITION_IMPACT_FACTOR] = true;
-        allowedBaseKeys[Keys.POSITION_IMPACT_EXPONENT_FACTOR] = true;
-        allowedBaseKeys[Keys.MAX_POSITION_IMPACT_FACTOR] = true;
-        allowedBaseKeys[Keys.POSITION_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.PRO_DISCOUNT_FACTOR] = true;
-        allowedBaseKeys[Keys.PRO_TRADER_TIER] = true;
-        allowedBaseKeys[Keys.LIQUIDATION_FEE_FACTOR] = true;
-
-        allowedBaseKeys[Keys.SWAP_IMPACT_FACTOR] = true;
-        allowedBaseKeys[Keys.SWAP_IMPACT_EXPONENT_FACTOR] = true;
-        allowedBaseKeys[Keys.SWAP_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.DEPOSIT_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.WITHDRAWAL_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.ATOMIC_SWAP_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.ATOMIC_WITHDRAWAL_FEE_FACTOR] = true;
-
-        allowedBaseKeys[Keys.MAX_UI_FEE_FACTOR] = true;
-        allowedBaseKeys[Keys.MAX_AUTO_CANCEL_ORDERS] = true;
-        allowedBaseKeys[Keys.MAX_TOTAL_CALLBACK_GAS_LIMIT_FOR_AUTO_CANCEL_ORDERS] = true;
-
-        allowedBaseKeys[Keys.ORACLE_TYPE] = true;
-
-        allowedBaseKeys[Keys.RESERVE_FACTOR] = true;
-        allowedBaseKeys[Keys.OPEN_INTEREST_RESERVE_FACTOR] = true;
-
-        allowedBaseKeys[Keys.MAX_PNL_FACTOR] = true;
-        allowedBaseKeys[Keys.MIN_PNL_FACTOR_AFTER_ADL] = true;
-
-        allowedBaseKeys[Keys.FUNDING_FACTOR] = true;
-        allowedBaseKeys[Keys.FUNDING_EXPONENT_FACTOR] = true;
-        allowedBaseKeys[Keys.FUNDING_INCREASE_FACTOR_PER_SECOND] = true;
-        allowedBaseKeys[Keys.FUNDING_DECREASE_FACTOR_PER_SECOND] = true;
-        allowedBaseKeys[Keys.MIN_FUNDING_FACTOR_PER_SECOND] = true;
-        allowedBaseKeys[Keys.MAX_FUNDING_FACTOR_PER_SECOND] = true;
-        allowedBaseKeys[Keys.THRESHOLD_FOR_STABLE_FUNDING] = true;
-        allowedBaseKeys[Keys.THRESHOLD_FOR_DECREASE_FUNDING] = true;
-
-        allowedBaseKeys[Keys.IGNORE_OPEN_INTEREST_FOR_USAGE_FACTOR] = true;
-
-        allowedBaseKeys[Keys.OPTIMAL_USAGE_FACTOR] = true;
-        allowedBaseKeys[Keys.BASE_BORROWING_FACTOR] = true;
-        allowedBaseKeys[Keys.ABOVE_OPTIMAL_USAGE_BORROWING_FACTOR] = true;
-        allowedBaseKeys[Keys.BORROWING_FACTOR] = true;
-        allowedBaseKeys[Keys.BORROWING_EXPONENT_FACTOR] = true;
-        allowedBaseKeys[Keys.SKIP_BORROWING_FEE_FOR_SMALLER_SIDE] = true;
-
-        allowedBaseKeys[Keys.PRICE_FEED_HEARTBEAT_DURATION] = true;
-
-        allowedBaseKeys[Keys.IS_GLV_MARKET_DISABLED] = true;
-        allowedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_USD] = true;
-        allowedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_AMOUNT] = true;
-        allowedBaseKeys[Keys.GLV_SHIFT_MAX_PRICE_IMPACT_FACTOR] = true;
-        allowedBaseKeys[Keys.GLV_SHIFT_MIN_INTERVAL] = true;
-        allowedBaseKeys[Keys.MIN_GLV_TOKENS_FOR_FIRST_DEPOSIT] = true;
-        allowedBaseKeys[Keys.GLV_MAX_MARKET_COUNT] = true;
-
-        allowedBaseKeys[Keys.SYNC_CONFIG_FEATURE_DISABLED] = true;
-        allowedBaseKeys[Keys.SYNC_CONFIG_MARKET_DISABLED] = true;
-        allowedBaseKeys[Keys.SYNC_CONFIG_PARAMETER_DISABLED] = true;
-        allowedBaseKeys[Keys.SYNC_CONFIG_MARKET_PARAMETER_DISABLED] = true;
-
-        allowedBaseKeys[Keys.BUYBACK_BATCH_AMOUNT] = true;
-        allowedBaseKeys[Keys.BUYBACK_GMX_FACTOR] = true;
-        allowedBaseKeys[Keys.BUYBACK_MAX_PRICE_IMPACT_FACTOR] = true;
-        allowedBaseKeys[Keys.BUYBACK_MAX_PRICE_AGE] = true;
-
-        allowedBaseKeys[Keys.DATA_STREAM_INVERTED] = true;
-        allowedBaseKeys[Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR] = true;
-
-        allowedBaseKeys[Keys.BASELINE_SWAP_LONGS_PAY_SHORTS] = true;
-        allowedBaseKeys[Keys.BASELINE_SWAP_PER_DAY] = true;
-
-        allowedBaseKeys[Keys.PYTH_LAZER_FEED_ID] = true;
-        allowedBaseKeys[Keys.PYTH_LAZER_FEED_INVERTED] = true;
-        allowedBaseKeys[Keys.PYTH_LAZER_FEED_MULTIPLIER] = true;
-    }
-
-    // function _initAllowedLimitedBaseKeys() internal {
-    //     allowedLimitedBaseKeys[Keys.ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1] = true;
-    //     allowedLimitedBaseKeys[Keys.ESTIMATED_GAS_FEE_PER_ORACLE_PRICE] = true;
-    //     allowedLimitedBaseKeys[Keys.ESTIMATED_GAS_FEE_MULTIPLIER_FACTOR] = true;
-    //
-    //     allowedLimitedBaseKeys[Keys.EXECUTION_GAS_FEE_BASE_AMOUNT_V2_1] = true;
-    //     allowedLimitedBaseKeys[Keys.EXECUTION_GAS_FEE_PER_ORACLE_PRICE] = true;
-    //     allowedLimitedBaseKeys[Keys.EXECUTION_GAS_FEE_MULTIPLIER_FACTOR] = true;
-    //
-    //     allowedLimitedBaseKeys[Keys.MAX_FUNDING_FACTOR_PER_SECOND] = true;
-    //     allowedLimitedBaseKeys[Keys.MIN_FUNDING_FACTOR_PER_SECOND] = true;
-    //     allowedLimitedBaseKeys[Keys.FUNDING_INCREASE_FACTOR_PER_SECOND] = true;
-    //     allowedLimitedBaseKeys[Keys.FUNDING_DECREASE_FACTOR_PER_SECOND] = true;
-    //
-    //     allowedLimitedBaseKeys[Keys.MAX_POOL_AMOUNT] = true;
-    //     allowedLimitedBaseKeys[Keys.MAX_POOL_USD_FOR_DEPOSIT] = true;
-    //     allowedLimitedBaseKeys[Keys.MAX_OPEN_INTEREST] = true;
-    //
-    //     allowedLimitedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_USD] = true;
-    //     allowedLimitedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_AMOUNT] = true;
-    //
-    //     allowedLimitedBaseKeys[Keys.PRO_TRADER_TIER] = true;
-    // }
-
     // @dev validate that the baseKey is allowed to be used
     // @param baseKey the base key to validate
     function _validateKey(bytes32 baseKey) internal view {
@@ -646,141 +425,4 @@ contract Config is ReentrancyGuard, RoleModule, BasicMulticall {
         revert Errors.InvalidBaseKey(baseKey);
     }
 
-    // @dev validate that the value is within the allowed range
-    // @param baseKey the base key for the value
-    // @param value the value to be set
-    function _validateRange(bytes32 baseKey, bytes memory data, uint256 value) internal view {
-        if (baseKey == Keys.SEQUENCER_GRACE_DURATION) {
-            // 2 hours
-            if (value > 7200) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.MAX_FUNDING_FACTOR_PER_SECOND) {
-            if (value > MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-
-            bytes32 minFundingFactorPerSecondKey = Keys.getFullKey(Keys.MIN_FUNDING_FACTOR_PER_SECOND, data);
-            uint256 minFundingFactorPerSecond = dataStore.getUint(minFundingFactorPerSecondKey);
-            if (value < minFundingFactorPerSecond) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.MIN_FUNDING_FACTOR_PER_SECOND) {
-            bytes32 maxFundingFactorPerSecondKey = Keys.getFullKey(Keys.MAX_FUNDING_FACTOR_PER_SECOND, data);
-            uint256 maxFundingFactorPerSecond = dataStore.getUint(maxFundingFactorPerSecondKey);
-            if (value > maxFundingFactorPerSecond) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.FUNDING_INCREASE_FACTOR_PER_SECOND) {
-            if (value > MAX_ALLOWED_FUNDING_INCREASE_FACTOR_PER_SECOND) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND) {
-            if (value > MAX_ALLOWED_FUNDING_DECREASE_FACTOR_PER_SECOND) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.BORROWING_FACTOR || baseKey == Keys.BASE_BORROWING_FACTOR) {
-            // 0.000005% per second, ~157% per year at 100% utilization
-            if (value > 50000000000000000000000) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.ABOVE_OPTIMAL_USAGE_BORROWING_FACTOR) {
-            // 0.00001% per second, ~315% per year at 100% utilization
-            if (value > 100000000000000000000000) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.FUNDING_EXPONENT_FACTOR || baseKey == Keys.BORROWING_EXPONENT_FACTOR) {
-            // revert if value > 2
-            if (value > 2 * Precision.FLOAT_PRECISION) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.POSITION_IMPACT_EXPONENT_FACTOR || baseKey == Keys.SWAP_IMPACT_EXPONENT_FACTOR) {
-            // revert if value > 3
-            if (value > 3 * Precision.FLOAT_PRECISION) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (
-            baseKey == Keys.FUNDING_FACTOR ||
-            baseKey == Keys.BORROWING_FACTOR ||
-            baseKey == Keys.FUNDING_INCREASE_FACTOR_PER_SECOND ||
-            baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND
-        ) {
-            // revert if value > 1%
-            if (value > (1 * Precision.FLOAT_PRECISION) / 100) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (
-            baseKey == Keys.SWAP_FEE_FACTOR ||
-            baseKey == Keys.DEPOSIT_FEE_FACTOR ||
-            baseKey == Keys.WITHDRAWAL_FEE_FACTOR ||
-            baseKey == Keys.POSITION_FEE_FACTOR ||
-            baseKey == Keys.MAX_UI_FEE_FACTOR ||
-            baseKey == Keys.ATOMIC_SWAP_FEE_FACTOR ||
-            baseKey == Keys.ATOMIC_WITHDRAWAL_FEE_FACTOR ||
-            baseKey == Keys.BUYBACK_MAX_PRICE_IMPACT_FACTOR
-        ) {
-            // revert if value > 5%
-            if (value > (5 * Precision.FLOAT_PRECISION) / 100) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        // if (baseKey == Keys.LIQUIDATION_FEE_FACTOR) {
-        //     // revert if value > 1%
-        //     if (value > Precision.FLOAT_PRECISION / 100) {
-        //         revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-        //     }
-        // }
-
-        if (baseKey == Keys.MIN_COLLATERAL_USD) {
-            // revert if value > 10 USD
-            if (value > 10 * Precision.FLOAT_PRECISION) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (
-            baseKey == Keys.POSITION_FEE_RECEIVER_FACTOR ||
-            baseKey == Keys.SWAP_FEE_RECEIVER_FACTOR ||
-            baseKey == Keys.BORROWING_FEE_RECEIVER_FACTOR ||
-            baseKey == Keys.LIQUIDATION_FEE_RECEIVER_FACTOR ||
-            baseKey == Keys.MAX_PNL_FACTOR ||
-            baseKey == Keys.MIN_PNL_FACTOR_AFTER_ADL ||
-            baseKey == Keys.OPTIMAL_USAGE_FACTOR ||
-            baseKey == Keys.PRO_DISCOUNT_FACTOR ||
-            baseKey == Keys.BUYBACK_GMX_FACTOR ||
-            baseKey == Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR
-        ) {
-            // revert if value > 100%
-            if (value > Precision.FLOAT_PRECISION) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-
-        if (baseKey == Keys.MAX_EXECUTION_FEE_MULTIPLIER_FACTOR) {
-            if (value < Precision.FLOAT_PRECISION * 10 || value > Precision.FLOAT_PRECISION * 100_000) {
-                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
-            }
-        }
-    }
 }

--- a/contracts/config/ConfigAllowedKeys.sol
+++ b/contracts/config/ConfigAllowedKeys.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../data/Keys.sol";
+
+// @title ConfigAllowedKeys
+// @dev Library that initializes the `allowedBaseKeys` whitelist used by Config.
+// Lifted from Config to keep Config under the EVM 24,576-byte contract size
+// limit. Pure storage init — no behavior change.
+library ConfigAllowedKeys {
+    // @dev populates the allowedBaseKeys mapping with every base key that the
+    //      generic Config setters (setBool / setAddress / setUint / setInt /
+    //      setBytes32) are permitted to write to. Called once from Config's
+    //      constructor with a storage pointer to its mapping.
+    function initAllowedBaseKeys(mapping(bytes32 => bool) storage allowedBaseKeys) internal {
+        allowedBaseKeys[Keys.HOLDING_ADDRESS] = true;
+
+        allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS] = true;
+        allowedBaseKeys[Keys.MIN_HANDLE_EXECUTION_ERROR_GAS_TO_FORWARD] = true;
+        allowedBaseKeys[Keys.MIN_ADDITIONAL_GAS_FOR_EXECUTION] = true;
+
+        allowedBaseKeys[Keys.IS_MARKET_DISABLED] = true;
+
+        allowedBaseKeys[Keys.MAX_SWAP_PATH_LENGTH] = true;
+        allowedBaseKeys[Keys.MAX_CALLBACK_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.REFUND_EXECUTION_FEE_GAS_LIMIT] = true;
+
+        allowedBaseKeys[Keys.MIN_POSITION_SIZE_USD] = true;
+        allowedBaseKeys[Keys.MAX_POSITION_IMPACT_FACTOR_FOR_LIQUIDATIONS] = true;
+
+        allowedBaseKeys[Keys.MAX_POOL_AMOUNT] = true;
+        allowedBaseKeys[Keys.MAX_POOL_USD_FOR_DEPOSIT] = true;
+        allowedBaseKeys[Keys.MAX_OPEN_INTEREST] = true;
+
+        allowedBaseKeys[Keys.MIN_MARKET_TOKENS_FOR_FIRST_DEPOSIT] = true;
+
+        allowedBaseKeys[Keys.CREATE_DEPOSIT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_DEPOSIT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_DEPOSIT_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_WITHDRAWAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_WITHDRAWAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_WITHDRAWAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_ATOMIC_WITHDRAWAL_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_SHIFT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_SHIFT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_SHIFT_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_ORDER_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_ORDER_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_ADL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.UPDATE_ORDER_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_ORDER_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_GLV_DEPOSIT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_GLV_DEPOSIT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_GLV_DEPOSIT_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CANCEL_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_GLV_WITHDRAWAL_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CREATE_GLV_SHIFT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.EXECUTE_GLV_SHIFT_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.CLAIM_FUNDING_FEES_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CLAIM_COLLATERAL_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CLAIM_AFFILIATE_REWARDS_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.CLAIM_UI_FEES_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.MIN_AFFILIATE_REWARD_FACTOR] = true;
+
+        allowedBaseKeys[Keys.SUBACCOUNT_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.GASLESS_FEATURE_DISABLED] = true;
+
+        allowedBaseKeys[Keys.MIN_ORACLE_BLOCK_CONFIRMATIONS] = true;
+        allowedBaseKeys[Keys.MAX_ORACLE_PRICE_AGE] = true;
+        allowedBaseKeys[Keys.MAX_ORACLE_TIMESTAMP_RANGE] = true;
+        allowedBaseKeys[Keys.ORACLE_TIMESTAMP_ADJUSTMENT] = true;
+        allowedBaseKeys[Keys.CHAINLINK_PAYMENT_TOKEN] = true;
+        allowedBaseKeys[Keys.SEQUENCER_GRACE_DURATION] = true;
+        allowedBaseKeys[Keys.MAX_ORACLE_REF_PRICE_DEVIATION_FACTOR] = true;
+
+        allowedBaseKeys[Keys.POSITION_FEE_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.POSITION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.SWAP_FEE_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.SWAP_FEE_SECONDARY_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.BORROWING_FEE_RECEIVER_FACTOR] = true;
+        allowedBaseKeys[Keys.BORROWING_FEE_SECONDARY_RECEIVER_FACTOR] = true;
+
+        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1] = true;
+        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_PER_ORACLE_PRICE] = true;
+        allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_MULTIPLIER_FACTOR] = true;
+
+        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_BASE_AMOUNT_V2_1] = true;
+        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_PER_ORACLE_PRICE] = true;
+        allowedBaseKeys[Keys.EXECUTION_GAS_FEE_MULTIPLIER_FACTOR] = true;
+
+        allowedBaseKeys[Keys.MAX_EXECUTION_FEE_MULTIPLIER_FACTOR] = true;
+
+        allowedBaseKeys[Keys.DEPOSIT_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.WITHDRAWAL_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.GLV_DEPOSIT_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.GLV_WITHDRAWAL_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.GLV_SHIFT_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.GLV_PER_MARKET_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.SHIFT_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.SINGLE_SWAP_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.INCREASE_ORDER_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.DECREASE_ORDER_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.SWAP_ORDER_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.TOKEN_TRANSFER_GAS_LIMIT] = true;
+        allowedBaseKeys[Keys.NATIVE_TOKEN_TRANSFER_GAS_LIMIT] = true;
+
+        allowedBaseKeys[Keys.REQUEST_EXPIRATION_TIME] = true;
+        allowedBaseKeys[Keys.MAX_LEVERAGE] = true;
+        allowedBaseKeys[Keys.MIN_LEVERAGE] = true;
+        allowedBaseKeys[Keys.MIN_MMR] = true;
+        allowedBaseKeys[Keys.MAX_MMR] = true;
+        allowedBaseKeys[Keys.MMR_TUNING] = true;
+        allowedBaseKeys[Keys.MIN_COLLATERAL_FACTOR_FOR_OPEN_INTEREST_MULTIPLIER] = true;
+        allowedBaseKeys[Keys.MIN_COLLATERAL_USD] = true;
+
+        allowedBaseKeys[Keys.VIRTUAL_TOKEN_ID] = true;
+        allowedBaseKeys[Keys.VIRTUAL_MARKET_ID] = true;
+        allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_SWAPS] = true;
+        allowedBaseKeys[Keys.VIRTUAL_INVENTORY_FOR_POSITIONS] = true;
+
+        allowedBaseKeys[Keys.POSITION_IMPACT_FACTOR] = true;
+        allowedBaseKeys[Keys.POSITION_IMPACT_EXPONENT_FACTOR] = true;
+        allowedBaseKeys[Keys.MAX_POSITION_IMPACT_FACTOR] = true;
+        allowedBaseKeys[Keys.POSITION_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.PRO_DISCOUNT_FACTOR] = true;
+        allowedBaseKeys[Keys.PRO_TRADER_TIER] = true;
+        allowedBaseKeys[Keys.LIQUIDATION_FEE_FACTOR] = true;
+
+        allowedBaseKeys[Keys.SWAP_IMPACT_FACTOR] = true;
+        allowedBaseKeys[Keys.SWAP_IMPACT_EXPONENT_FACTOR] = true;
+        allowedBaseKeys[Keys.SWAP_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.DEPOSIT_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.WITHDRAWAL_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.ATOMIC_SWAP_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.ATOMIC_WITHDRAWAL_FEE_FACTOR] = true;
+
+        allowedBaseKeys[Keys.MAX_UI_FEE_FACTOR] = true;
+        allowedBaseKeys[Keys.MAX_AUTO_CANCEL_ORDERS] = true;
+        allowedBaseKeys[Keys.MAX_TOTAL_CALLBACK_GAS_LIMIT_FOR_AUTO_CANCEL_ORDERS] = true;
+
+        allowedBaseKeys[Keys.ORACLE_TYPE] = true;
+
+        allowedBaseKeys[Keys.RESERVE_FACTOR] = true;
+        allowedBaseKeys[Keys.OPEN_INTEREST_RESERVE_FACTOR] = true;
+
+        allowedBaseKeys[Keys.MAX_PNL_FACTOR] = true;
+        allowedBaseKeys[Keys.MIN_PNL_FACTOR_AFTER_ADL] = true;
+
+        allowedBaseKeys[Keys.FUNDING_FACTOR] = true;
+        allowedBaseKeys[Keys.FUNDING_EXPONENT_FACTOR] = true;
+        allowedBaseKeys[Keys.FUNDING_INCREASE_FACTOR_PER_SECOND] = true;
+        allowedBaseKeys[Keys.FUNDING_DECREASE_FACTOR_PER_SECOND] = true;
+        allowedBaseKeys[Keys.MIN_FUNDING_FACTOR_PER_SECOND] = true;
+        allowedBaseKeys[Keys.MAX_FUNDING_FACTOR_PER_SECOND] = true;
+        allowedBaseKeys[Keys.THRESHOLD_FOR_STABLE_FUNDING] = true;
+        allowedBaseKeys[Keys.THRESHOLD_FOR_DECREASE_FUNDING] = true;
+
+        allowedBaseKeys[Keys.IGNORE_OPEN_INTEREST_FOR_USAGE_FACTOR] = true;
+
+        allowedBaseKeys[Keys.OPTIMAL_USAGE_FACTOR] = true;
+        allowedBaseKeys[Keys.BASE_BORROWING_FACTOR] = true;
+        allowedBaseKeys[Keys.ABOVE_OPTIMAL_USAGE_BORROWING_FACTOR] = true;
+        allowedBaseKeys[Keys.BORROWING_FACTOR] = true;
+        allowedBaseKeys[Keys.BORROWING_EXPONENT_FACTOR] = true;
+        allowedBaseKeys[Keys.SKIP_BORROWING_FEE_FOR_SMALLER_SIDE] = true;
+
+        allowedBaseKeys[Keys.PRICE_FEED_HEARTBEAT_DURATION] = true;
+
+        allowedBaseKeys[Keys.IS_GLV_MARKET_DISABLED] = true;
+        allowedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_USD] = true;
+        allowedBaseKeys[Keys.GLV_MAX_MARKET_TOKEN_BALANCE_AMOUNT] = true;
+        allowedBaseKeys[Keys.GLV_SHIFT_MAX_PRICE_IMPACT_FACTOR] = true;
+        allowedBaseKeys[Keys.GLV_SHIFT_MIN_INTERVAL] = true;
+        allowedBaseKeys[Keys.MIN_GLV_TOKENS_FOR_FIRST_DEPOSIT] = true;
+        allowedBaseKeys[Keys.GLV_MAX_MARKET_COUNT] = true;
+
+        allowedBaseKeys[Keys.SYNC_CONFIG_FEATURE_DISABLED] = true;
+        allowedBaseKeys[Keys.SYNC_CONFIG_MARKET_DISABLED] = true;
+        allowedBaseKeys[Keys.SYNC_CONFIG_PARAMETER_DISABLED] = true;
+        allowedBaseKeys[Keys.SYNC_CONFIG_MARKET_PARAMETER_DISABLED] = true;
+
+        allowedBaseKeys[Keys.BUYBACK_BATCH_AMOUNT] = true;
+        allowedBaseKeys[Keys.BUYBACK_GMX_FACTOR] = true;
+        allowedBaseKeys[Keys.BUYBACK_MAX_PRICE_IMPACT_FACTOR] = true;
+        allowedBaseKeys[Keys.BUYBACK_MAX_PRICE_AGE] = true;
+
+        allowedBaseKeys[Keys.DATA_STREAM_INVERTED] = true;
+        allowedBaseKeys[Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR] = true;
+
+        allowedBaseKeys[Keys.BASELINE_SWAP_LONGS_PAY_SHORTS] = true;
+        allowedBaseKeys[Keys.BASELINE_SWAP_PER_DAY] = true;
+
+        allowedBaseKeys[Keys.PYTH_LAZER_FEED_ID] = true;
+        allowedBaseKeys[Keys.PYTH_LAZER_FEED_INVERTED] = true;
+        allowedBaseKeys[Keys.PYTH_LAZER_FEED_MULTIPLIER] = true;
+    }
+}

--- a/contracts/config/ConfigValidatorUtils.sol
+++ b/contracts/config/ConfigValidatorUtils.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../data/DataStore.sol";
+import "../data/Keys.sol";
+import "../error/Errors.sol";
+import "../utils/Precision.sol";
+
+// @title ConfigValidatorUtils
+// @dev Library that range-checks values being written through Config's generic
+// uint setter. Lifted from Config to keep Config under the EVM 24,576-byte
+// contract size limit. Pure validation — no behavior change.
+library ConfigValidatorUtils {
+    // 0.00001% per second, ~315% per year
+    uint256 internal constant MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND = 100000000000000000000000;
+    // at this rate max allowed funding rate will be reached in 1 hour at 100% imbalance if max funding rate is 315%
+    uint256 internal constant MAX_ALLOWED_FUNDING_INCREASE_FACTOR_PER_SECOND =
+        MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND / 1 hours;
+    // at this rate zero funding rate will be reached in 24 hours if max funding rate is 315%
+    uint256 internal constant MAX_ALLOWED_FUNDING_DECREASE_FACTOR_PER_SECOND =
+        MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND / 24 hours;
+
+    // @dev validate that the value being set is within the allowed range for
+    //      the given baseKey. Reverts with ConfigValueExceedsAllowedRange on
+    //      out-of-bounds values. Reads dataStore for cross-parameter checks
+    //      (e.g. min/max funding factor pair).
+    function validateRange(
+        DataStore dataStore,
+        bytes32 baseKey,
+        bytes memory data,
+        uint256 value
+    ) external view {
+        if (baseKey == Keys.SEQUENCER_GRACE_DURATION) {
+            // 2 hours
+            if (value > 7200) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.MAX_FUNDING_FACTOR_PER_SECOND) {
+            if (value > MAX_ALLOWED_MAX_FUNDING_FACTOR_PER_SECOND) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+
+            bytes32 minFundingFactorPerSecondKey = Keys.getFullKey(Keys.MIN_FUNDING_FACTOR_PER_SECOND, data);
+            uint256 minFundingFactorPerSecond = dataStore.getUint(minFundingFactorPerSecondKey);
+            if (value < minFundingFactorPerSecond) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.MIN_FUNDING_FACTOR_PER_SECOND) {
+            bytes32 maxFundingFactorPerSecondKey = Keys.getFullKey(Keys.MAX_FUNDING_FACTOR_PER_SECOND, data);
+            uint256 maxFundingFactorPerSecond = dataStore.getUint(maxFundingFactorPerSecondKey);
+            if (value > maxFundingFactorPerSecond) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.FUNDING_INCREASE_FACTOR_PER_SECOND) {
+            if (value > MAX_ALLOWED_FUNDING_INCREASE_FACTOR_PER_SECOND) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND) {
+            if (value > MAX_ALLOWED_FUNDING_DECREASE_FACTOR_PER_SECOND) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.BORROWING_FACTOR || baseKey == Keys.BASE_BORROWING_FACTOR) {
+            // 0.000005% per second, ~157% per year at 100% utilization
+            if (value > 50000000000000000000000) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.ABOVE_OPTIMAL_USAGE_BORROWING_FACTOR) {
+            // 0.00001% per second, ~315% per year at 100% utilization
+            if (value > 100000000000000000000000) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.FUNDING_EXPONENT_FACTOR || baseKey == Keys.BORROWING_EXPONENT_FACTOR) {
+            // revert if value > 2
+            if (value > 2 * Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.POSITION_IMPACT_EXPONENT_FACTOR || baseKey == Keys.SWAP_IMPACT_EXPONENT_FACTOR) {
+            // revert if value > 3
+            if (value > 3 * Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (
+            baseKey == Keys.FUNDING_FACTOR ||
+            baseKey == Keys.BORROWING_FACTOR ||
+            baseKey == Keys.FUNDING_INCREASE_FACTOR_PER_SECOND ||
+            baseKey == Keys.FUNDING_DECREASE_FACTOR_PER_SECOND
+        ) {
+            // revert if value > 1%
+            if (value > (1 * Precision.FLOAT_PRECISION) / 100) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (
+            baseKey == Keys.SWAP_FEE_FACTOR ||
+            baseKey == Keys.DEPOSIT_FEE_FACTOR ||
+            baseKey == Keys.WITHDRAWAL_FEE_FACTOR ||
+            baseKey == Keys.POSITION_FEE_FACTOR ||
+            baseKey == Keys.MAX_UI_FEE_FACTOR ||
+            baseKey == Keys.ATOMIC_SWAP_FEE_FACTOR ||
+            baseKey == Keys.ATOMIC_WITHDRAWAL_FEE_FACTOR ||
+            baseKey == Keys.BUYBACK_MAX_PRICE_IMPACT_FACTOR
+        ) {
+            // revert if value > 5%
+            if (value > (5 * Precision.FLOAT_PRECISION) / 100) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        // if (baseKey == Keys.LIQUIDATION_FEE_FACTOR) {
+        //     // revert if value > 1%
+        //     if (value > Precision.FLOAT_PRECISION / 100) {
+        //         revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+        //     }
+        // }
+
+        if (baseKey == Keys.MIN_COLLATERAL_USD) {
+            // revert if value > 10 USD
+            if (value > 10 * Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (
+            baseKey == Keys.POSITION_FEE_RECEIVER_FACTOR ||
+            baseKey == Keys.SWAP_FEE_RECEIVER_FACTOR ||
+            baseKey == Keys.BORROWING_FEE_RECEIVER_FACTOR ||
+            baseKey == Keys.LIQUIDATION_FEE_RECEIVER_FACTOR ||
+            baseKey == Keys.MAX_PNL_FACTOR ||
+            baseKey == Keys.MIN_PNL_FACTOR_AFTER_ADL ||
+            baseKey == Keys.OPTIMAL_USAGE_FACTOR ||
+            baseKey == Keys.PRO_DISCOUNT_FACTOR ||
+            baseKey == Keys.BUYBACK_GMX_FACTOR ||
+            baseKey == Keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR
+        ) {
+            // revert if value > 100%
+            if (value > Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        if (baseKey == Keys.MAX_EXECUTION_FEE_MULTIPLIER_FACTOR) {
+            if (value < Precision.FLOAT_PRECISION * 10 || value > Precision.FLOAT_PRECISION * 100_000) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+    }
+}

--- a/deploy/deployConfig.ts
+++ b/deploy/deployConfig.ts
@@ -9,7 +9,7 @@ const func = createDeployFunction({
   getDeployArgs: async ({ dependencyContracts }) => {
     return constructorContracts.map((dependencyName) => dependencyContracts[dependencyName].address);
   },
-  libraryNames: ["MarketUtils"],
+  libraryNames: ["MarketUtils", "ConfigValidatorUtils"],
   afterDeploy: async ({ deployedContract }) => {
     await grantRoleIfNotGranted(deployedContract.address, "CONTROLLER");
   },

--- a/deploy/deployConfigValidatorUtils.ts
+++ b/deploy/deployConfigValidatorUtils.ts
@@ -1,0 +1,7 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const func = createDeployFunction({
+  contractName: "ConfigValidatorUtils",
+});
+
+export default func;


### PR DESCRIPTION
Config and PositionUtils currently fit under 24,576 bytes on dev with margins of 859 and 361 respectively. The leverage-ladder PR  adds ~2,700 bytes to Config and ~780 to PositionUtils, which would push both over. This PR creates ~5KB of headroom in Config preemptively so the ladder PR can land without bundling unrelated refactor work into a feature PR.
Changes:
- New library ConfigAllowedKeys.sol holding the 192-key allowedBaseKeys init (called once from Config's constructor with a storage pointer; remains internal so it inlines, no extra deploy).
- New library ConfigValidatorUtils.sol holding the ~140-line range validator used by setUint and setDataStream. Function is external so the bytecode lives off-Config and is reached via DELEGATECALL — this is what unlocks the size win.
- Constants MAX_ALLOWED_*_FUNDING_FACTOR_PER_SECOND moved into the validator library since they were only used by the lifted code.
- deploy/deployConfigValidatorUtils.ts (new), deployConfig.ts adds the new library to libraryNames so hardhat-deploy links and orders correctly.

No public API change. allowedBaseKeys mapping, all setters, modifiers, constructor signature unchanged. Existing Config + ConfigSyncer tests pass unchanged.

Sizes:
  Config: 26,444 -> 19,618 bytes (-6,826, +4,958 headroom under limit)

Trade-off: setUint and setDataStream now do one extra DELEGATECALL into the validator library (~700 gas). Both are governance-only paths called rarely.