### PR TITLE
feat(insurance): foundation — keys, vault, InsuranceFundUtils library, unit tests

### DIFF
--- a/.husky/_
+++ b/.husky/_
@@ -1,0 +1,1 @@
+/Users/joshuaguessennd/Desktop/ContagoCapital/0xMarket/work/0xmarkets_contract/.husky/_

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -19,6 +19,12 @@ library Keys {
     // @dev for holding tokens that could not be sent out
     bytes32 public constant HOLDING_ADDRESS = keccak256(abi.encode("HOLDING_ADDRESS"));
 
+    // @dev address of the singleton InsuranceVault that custodies per-market
+    // insurance reserves. Resolved at runtime from DataStore because the
+    // injection runs inside InsuranceFundUtils (a library) and libraries
+    // cannot hold immutable state, matching the pattern used for HOLDING_ADDRESS.
+    bytes32 public constant INSURANCE_VAULT = keccak256(abi.encode("INSURANCE_VAULT"));
+
     // @dev key for the minimum gas for execution error
     bytes32 public constant MIN_HANDLE_EXECUTION_ERROR_GAS = keccak256(abi.encode("MIN_HANDLE_EXECUTION_ERROR_GAS"));
 
@@ -213,6 +219,34 @@ library Keys {
     // @dev key for the percentage amount of borrowing fees to be received
     bytes32 public constant BORROWING_FEE_RECEIVER_FACTOR = keccak256(abi.encode("BORROWING_FEE_RECEIVER_FACTOR"));
     bytes32 public constant BORROWING_FEE_SECONDARY_RECEIVER_FACTOR = keccak256(abi.encode("BORROWING_FEE_SECONDARY_RECEIVER_FACTOR"));
+
+    // @dev per-market share of liquidationFeeAmount routed into the insurance fund reserve.
+    // Default 0 (off). Range bound enforced in Config._validateRange.
+    bytes32 public constant INSURANCE_FUND_FEE_FACTOR = keccak256(abi.encode("INSURANCE_FUND_FEE_FACTOR"));
+    // @dev per-market share of positionFeeAmount routed into the insurance fund reserve.
+    // Same shape as the liquidation slice; collected on every close, not just liquidations,
+    // so the fund keeps accruing in calm markets and isn't starved when the fund actually matters
+    // (insolvent liquidations skip liquidation-fee collection — see DecreasePositionCollateralUtils.handleEarlyReturn).
+    bytes32 public constant INSURANCE_FUND_POSITION_FEE_FACTOR = keccak256(abi.encode("INSURANCE_FUND_POSITION_FEE_FACTOR"));
+    // @dev per-market realized-drawdown threshold; the fund injects when drawdown fraction exceeds this.
+    // Default type(uint256).max (off).
+    bytes32 public constant INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR = keccak256(abi.encode("INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR"));
+    // @dev per (market, token) reserve balance. Tokens are physically held by the InsuranceVault
+    // singleton; this DataStore entry is the bookkeeping segregating reserves by market+token.
+    // Invariant: InsuranceVault.tokenBalance(token) >= sum over markets of insuranceFundBalanceKey(market, token).
+    bytes32 public constant INSURANCE_FUND_BALANCE = keccak256(abi.encode("INSURANCE_FUND_BALANCE"));
+    // @dev per-market USD snapshot of poolValueExcludingUnrealizedPnl at the last epoch start.
+    // v1 is USD-denominated. A v2 upgrade to token-denominated snapshots will replace this with
+    // per-token amount snapshots; the key name is preserved here for the USD path.
+    bytes32 public constant INSURANCE_FUND_EPOCH_POOL_VALUE = keccak256(abi.encode("INSURANCE_FUND_EPOCH_POOL_VALUE"));
+    // @dev per-market timestamp of the last epoch start. Treat the fund as disabled
+    // when this is zero (first epoch) or older than MAX_EPOCH_AGE (stale snapshot).
+    bytes32 public constant INSURANCE_FUND_EPOCH_START = keccak256(abi.encode("INSURANCE_FUND_EPOCH_START"));
+    // @dev maximum allowed age of an epoch snapshot before the fund auto-disables (global, seconds).
+    // Guards against a keeper missing the Friday snapshot and the next week running off a stale baseline.
+    bytes32 public constant INSURANCE_FUND_MAX_EPOCH_AGE = keccak256(abi.encode("INSURANCE_FUND_MAX_EPOCH_AGE"));
+    // @dev epoch length used by SettlementHandler.snapshotEpoch idempotency guard (global, seconds).
+    bytes32 public constant INSURANCE_FUND_EPOCH_LENGTH = keccak256(abi.encode("INSURANCE_FUND_EPOCH_LENGTH"));
 
     // @dev key for the base gas limit used when estimating execution fee
     bytes32 public constant ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1 = keccak256(abi.encode("ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1"));
@@ -1206,6 +1240,55 @@ library Keys {
     function liquidationFeeFactorKey(address market) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             LIQUIDATION_FEE_FACTOR,
+            market
+        ));
+    }
+
+    // @dev key for the share of liquidationFeeAmount routed into the insurance fund (per market)
+    function insuranceFundFeeFactorKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_FEE_FACTOR,
+            market
+        ));
+    }
+
+    // @dev key for the share of positionFeeAmount routed into the insurance fund (per market)
+    function insuranceFundPositionFeeFactorKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_POSITION_FEE_FACTOR,
+            market
+        ));
+    }
+
+    // @dev key for the realized-drawdown trigger threshold (per market)
+    function insuranceFundDrawdownTriggerFactorKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR,
+            market
+        ));
+    }
+
+    // @dev key for the per (market, token) insurance reserve balance
+    function insuranceFundBalanceKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_BALANCE,
+            market,
+            token
+        ));
+    }
+
+    // @dev key for the per-market USD pool-value snapshot at last epoch start
+    function insuranceFundEpochPoolValueKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_EPOCH_POOL_VALUE,
+            market
+        ));
+    }
+
+    // @dev key for the per-market timestamp of the last epoch start
+    function insuranceFundEpochStartKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_EPOCH_START,
             market
         ));
     }

--- a/contracts/insurance/InsuranceFundEventUtils.sol
+++ b/contracts/insurance/InsuranceFundEventUtils.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../event/EventEmitter.sol";
+import "../event/EventUtils.sol";
+import "../utils/Cast.sol";
+
+// @title InsuranceFundEventUtils
+// @dev Emits the per-action events for the insurance fund.
+// Mirrors the MarketEventUtils style so the subsquid indexer can pick these
+// up with the same EventEmitter routing.
+library InsuranceFundEventUtils {
+    using EventUtils for EventUtils.AddressItems;
+    using EventUtils for EventUtils.UintItems;
+    using EventUtils for EventUtils.IntItems;
+    using EventUtils for EventUtils.BoolItems;
+    using EventUtils for EventUtils.Bytes32Items;
+    using EventUtils for EventUtils.BytesItems;
+    using EventUtils for EventUtils.StringItems;
+
+    // Emitted when the per-close liquidation/position-fee slice is moved from
+    // MarketToken into the InsuranceVault and the reserve bucket is incremented.
+    function emitInsuranceFundDeposit(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount,
+        uint256 newBalance
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newBalance", newBalance);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundDeposit",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when reserves are transferred from the InsuranceVault into MarketToken
+    // and credited to the pool via applyDeltaToPoolAmount.
+    function emitInsuranceFundInjection(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount,
+        uint256 newPoolAmount,
+        uint256 newReserveBalance,
+        uint256 drawdownBefore,
+        uint256 drawdownAfter
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(5);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newPoolAmount", newPoolAmount);
+        eventData.uintItems.setItem(2, "newReserveBalance", newReserveBalance);
+        eventData.uintItems.setItem(3, "drawdownBefore", drawdownBefore);
+        eventData.uintItems.setItem(4, "drawdownAfter", drawdownAfter);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundInjection",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when an injection was requested but the (market, token) reserve
+    // could not cover the full amount. paid == 0 means nothing was injected.
+    // Distinct from InsuranceFundInjection because operators alert on this:
+    // a recurring shortfall means the reserve is undersized for the market.
+    function emitInsuranceFundShortfall(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 requested,
+        uint256 paid
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "requested", requested);
+        eventData.uintItems.setItem(1, "paid", paid);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundShortfall",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when SettlementHandler snapshots pool value at epoch start.
+    function emitInsuranceFundEpochReset(
+        EventEmitter eventEmitter,
+        address market,
+        uint256 epochPoolValue,
+        uint256 timestamp
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(1);
+        eventData.addressItems.setItem(0, "market", market);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "epochPoolValue", epochPoolValue);
+        eventData.uintItems.setItem(1, "timestamp", timestamp);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundEpochReset",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted on governance-initiated topUp from treasury (out-of-band seeding).
+    function emitInsuranceFundManualDeposit(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount,
+        uint256 newBalance
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(3);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+        eventData.addressItems.setItem(2, "depositor", depositor);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newBalance", newBalance);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundManualDeposit",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+}

--- a/contracts/insurance/InsuranceFundUtils.sol
+++ b/contracts/insurance/InsuranceFundUtils.sol
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-v4/utils/math/SafeCast.sol";
+
+import "../data/DataStore.sol";
+import "../data/Keys.sol";
+import "../event/EventEmitter.sol";
+import "../market/Market.sol";
+import "../market/MarketToken.sol";
+import "../market/MarketUtils.sol";
+import "../price/Price.sol";
+import "../utils/Precision.sol";
+
+import "./InsuranceVault.sol";
+import "./InsuranceFundEventUtils.sol";
+
+// @title InsuranceFundUtils
+// @dev Per-market insurance reserve logic. Three responsibilities:
+//   1. Collect a configurable slice of liquidation/position fees into the
+//      InsuranceVault (deposit).
+//   2. Inject capital from the vault back into MarketToken when realized
+//      pool drawdown exceeds the per-market trigger threshold
+//      (attemptInjectPool).
+//   3. Snapshot the per-market pool USD value at epoch boundaries so
+//      drawdown can be computed against a stable baseline (snapshotEpoch).
+//
+// The vault is a singleton; per-market and per-token segregation is
+// bookkeeping in DataStore. Callers must already hold the CONTROLLER role
+// on MarketToken and the InsuranceVault — the protocol handlers do.
+library InsuranceFundUtils {
+    using SafeCast for int256;
+    using SafeCast for uint256;
+
+    using Price for Price.Props;
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    function getBalance(DataStore dataStore, address market, address token) internal view returns (uint256) {
+        return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+    }
+
+    // @dev Computes the current realized drawdown fraction for a market.
+    //
+    // Returns (0, currentValue, epochValue) when the fund is **disabled**
+    // for that market, which is any of:
+    //   - first epoch (epochValue == 0, snapshotEpoch never ran)
+    //   - stale snapshot (block.timestamp - epochStart > MAX_EPOCH_AGE)
+    //   - pool currently at or above the epoch snapshot (no drawdown)
+    //
+    // Uses minimize=false for the pool-value lookup so the snapshot and
+    // current measurement use the same price-pick rule. Both use the LP-
+    // conservative "minimize" pickPrice so a stressed-LP read is always
+    // the larger number (better protection).
+    function getDrawdownFraction(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) internal view returns (uint256 drawdownFraction, uint256 currentPoolValueUsd, uint256 epochPoolValueUsd) {
+        int256 cur = MarketUtils.getPoolValueExcludingUnrealizedPnl(dataStore, market, prices, false);
+        currentPoolValueUsd = cur < 0 ? 0 : uint256(cur);
+
+        epochPoolValueUsd = dataStore.getUint(Keys.insuranceFundEpochPoolValueKey(market.marketToken));
+        if (epochPoolValueUsd == 0) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        uint256 epochStart = dataStore.getUint(Keys.insuranceFundEpochStartKey(market.marketToken));
+        uint256 maxAge = dataStore.getUint(Keys.INSURANCE_FUND_MAX_EPOCH_AGE);
+        // maxAge == 0 disables the stale check (treat as no upper bound).
+        // A keeper-supplied maxAge of e.g. 8 days bounds how long a missed
+        // Friday snapshot can poison subsequent drawdown calculations.
+        if (maxAge > 0 && epochStart != 0 && block.timestamp - epochStart > maxAge) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        if (currentPoolValueUsd >= epochPoolValueUsd) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        uint256 drawdownUsd = epochPoolValueUsd - currentPoolValueUsd;
+        // 1e30-scaled fraction. epochPoolValueUsd is non-zero by the check above.
+        drawdownFraction = (drawdownUsd * Precision.FLOAT_PRECISION) / epochPoolValueUsd;
+    }
+
+    // ---------------------------------------------------------------------
+    // Collection
+    // ---------------------------------------------------------------------
+
+    // @dev Moves `amount` of `token` from MarketToken into the InsuranceVault
+    // and increments the per (market, token) reserve bookkeeping.
+    //
+    // Idempotent on zero (no-op rather than revert) so callers can pass the
+    // computed slice unconditionally without an outer check.
+    function deposit(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount
+    ) internal returns (uint256 newBalance) {
+        if (amount == 0) {
+            return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+        }
+
+        MarketToken(payable(market)).transferOut(token, address(vault), amount);
+        // recordTransferIn returns the delta vs. previously-tracked balance.
+        // We ignore the return value because the bookkeeping increment uses
+        // the requested `amount`; if a non-standard token (fee-on-transfer)
+        // delivered less, the invariant
+        //   vault.tokenBalances(token) >= sum(reserve buckets)
+        // would fail, which is the correct posture — we don't support such
+        // tokens as pnl/collateral in any market.
+        vault.recordTransferIn(token);
+
+        newBalance = dataStore.incrementUint(Keys.insuranceFundBalanceKey(market, token), amount);
+
+        InsuranceFundEventUtils.emitInsuranceFundDeposit(
+            eventEmitter,
+            market,
+            token,
+            orderKey,
+            amount,
+            newBalance
+        );
+    }
+
+    // @dev Governance-initiated reserve top-up from treasury.
+    //
+    // Two-phase: external caller must first transfer `amount` of `token`
+    // into the vault, then call this to record the transfer and increment
+    // the bucket. Mirrors the protocol's "send then record" pattern (see
+    // ExchangeRouter deposits).
+    function topUp(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount
+    ) internal returns (uint256 newBalance) {
+        if (amount == 0) {
+            return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+        }
+
+        // recordTransferIn reads balanceOf and subtracts the prior cached
+        // value; reverts implicitly if the depositor under-transferred.
+        uint256 received = vault.recordTransferIn(token);
+        require(received >= amount, "InsuranceFundUtils: under-funded topUp");
+
+        newBalance = dataStore.incrementUint(Keys.insuranceFundBalanceKey(market, token), amount);
+
+        InsuranceFundEventUtils.emitInsuranceFundManualDeposit(
+            eventEmitter,
+            market,
+            token,
+            depositor,
+            amount,
+            newBalance
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Injection
+    // ---------------------------------------------------------------------
+
+    // @dev If realized drawdown exceeds the per-market trigger factor,
+    // transfers `pnlToken` from the InsuranceVault into MarketToken and
+    // credits the pool via applyDeltaToPoolAmount until drawdown returns
+    // to threshold (or the reserve bucket is drained).
+    //
+    // Returns the number of tokens actually injected (0 if no trigger or
+    // empty reserve). Never reverts on insufficient reserve — emits
+    // InsuranceFundShortfall and proceeds.
+    //
+    // Wiring: this is intended to be called once at the end of
+    // DecreasePositionCollateralUtils.processCollateral, after all
+    // applyDeltaToPoolAmount branches have settled. ADL and liquidation
+    // paths flow through the same `processCollateral`, so they pick this
+    // up automatically.
+    function attemptInjectPool(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        bytes32 orderKey
+    ) internal returns (uint256 injectedAmount) {
+        uint256 triggerFactor = dataStore.getUint(Keys.insuranceFundDrawdownTriggerFactorKey(market.marketToken));
+        // type(uint256).max is the "off" sentinel; default value of an unset
+        // key is 0, which would semantically mean "inject on any drawdown",
+        // so the unset-by-default state is the wrong direction. Operators
+        // must explicitly set type(uint256).max in Config to mark a market
+        // as not-yet-onboarded. (Spec §4.1 lists this as the default; the
+        // deploy script must initialize accordingly.)
+        if (triggerFactor == type(uint256).max) {
+            return 0;
+        }
+
+        uint256 drawdownBefore;
+        uint256 requestedTokens;
+        {
+            (uint256 _drawdownBefore, uint256 currentValue, uint256 epochValue) = getDrawdownFraction(dataStore, market, prices);
+            if (_drawdownBefore <= triggerFactor) {
+                return 0;
+            }
+            drawdownBefore = _drawdownBefore;
+            requestedTokens = _computeRequestedInjection(
+                market,
+                prices,
+                pnlToken,
+                currentValue,
+                epochValue,
+                triggerFactor
+            );
+            if (requestedTokens == 0) {
+                return 0;
+            }
+        }
+
+        uint256 reserveBalance = dataStore.getUint(Keys.insuranceFundBalanceKey(market.marketToken, pnlToken));
+        if (reserveBalance == 0) {
+            InsuranceFundEventUtils.emitInsuranceFundShortfall(
+                eventEmitter,
+                market.marketToken,
+                pnlToken,
+                orderKey,
+                requestedTokens,
+                0
+            );
+            return 0;
+        }
+
+        injectedAmount = requestedTokens > reserveBalance ? reserveBalance : requestedTokens;
+
+        // Physical move vault → marketToken. The vault's _afterTransferOut
+        // hook (StrictBank) re-syncs its tokenBalances mapping.
+        vault.transferOut(pnlToken, market.marketToken, injectedAmount);
+
+        // Pool accounting credit. Also tweaks virtual swap inventory as a
+        // side-effect inside applyDeltaToPoolAmount — see review §1.6.
+        uint256 newPoolAmount = MarketUtils.applyDeltaToPoolAmount(
+            dataStore,
+            eventEmitter,
+            market,
+            pnlToken,
+            injectedAmount.toInt256()
+        );
+
+        // Decrement the reserve bucket.
+        uint256 newReserveBalance = dataStore.applyDeltaToUint(
+            Keys.insuranceFundBalanceKey(market.marketToken, pnlToken),
+            -injectedAmount.toInt256(),
+            "Invalid state, negative insurance reserve"
+        );
+
+        // Recompute drawdown post-injection for the event payload. Cheaper
+        // alternatives exist (subtract injectedAmount*price/epochValue from
+        // drawdownBefore) but a fresh read is robust against any concurrent
+        // pool-amount changes within this tx.
+        (uint256 drawdownAfter, , ) = getDrawdownFraction(dataStore, market, prices);
+
+        InsuranceFundEventUtils.emitInsuranceFundInjection(
+            eventEmitter,
+            market.marketToken,
+            pnlToken,
+            orderKey,
+            injectedAmount,
+            newPoolAmount,
+            newReserveBalance,
+            drawdownBefore,
+            drawdownAfter
+        );
+
+        if (injectedAmount < requestedTokens) {
+            InsuranceFundEventUtils.emitInsuranceFundShortfall(
+                eventEmitter,
+                market.marketToken,
+                pnlToken,
+                orderKey,
+                requestedTokens,
+                injectedAmount
+            );
+        }
+    }
+
+    // @dev Compute the number of pnlToken units needed to bring drawdown
+    // back to threshold. Extracted from attemptInjectPool so the
+    // intermediate locals (target, missing, pnlTokenPrice) don't pin slots
+    // on the caller's stack — stack-too-deep otherwise.
+    function _computeRequestedInjection(
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        uint256 currentValue,
+        uint256 epochValue,
+        uint256 triggerFactor
+    ) private pure returns (uint256) {
+        uint256 targetCurrentValue = Precision.applyFactor(
+            epochValue,
+            Precision.FLOAT_PRECISION - triggerFactor
+        );
+        // drawdownBefore > triggerFactor (caller checked) ⇒ currentValue < targetCurrentValue.
+        uint256 missingUsd = targetCurrentValue - currentValue;
+
+        // Use pnlTokenPrice.min so we slightly over-inject (LP-favorable rounding).
+        Price.Props memory pnlTokenPrice = MarketUtils.getCachedTokenPrice(pnlToken, market, prices);
+        return missingUsd / pnlTokenPrice.min;
+    }
+
+    // ---------------------------------------------------------------------
+    // Epoch lifecycle
+    // ---------------------------------------------------------------------
+
+    // @dev Snapshots the current pool USD (excluding unrealized PnL) as the
+    // baseline for the next epoch's drawdown calculation, and stamps the
+    // epoch-start timestamp.
+    //
+    // Idempotency / freshness is the caller's concern — SettlementHandler
+    // enforces an epoch-length gap. This function unconditionally writes.
+    function snapshotEpoch(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) internal returns (uint256 epochValue) {
+        // minimize=false matches getDrawdownFraction's call so both sides
+        // use the same price-pick rule. (Snapshot pick must match current
+        // pick or drawdown will mis-fire.)
+        int256 poolValue = MarketUtils.getPoolValueExcludingUnrealizedPnl(dataStore, market, prices, false);
+        epochValue = poolValue < 0 ? 0 : uint256(poolValue);
+
+        dataStore.setUint(Keys.insuranceFundEpochPoolValueKey(market.marketToken), epochValue);
+        dataStore.setUint(Keys.insuranceFundEpochStartKey(market.marketToken), block.timestamp);
+
+        InsuranceFundEventUtils.emitInsuranceFundEpochReset(
+            eventEmitter,
+            market.marketToken,
+            epochValue,
+            block.timestamp
+        );
+    }
+}

--- a/contracts/insurance/InsuranceVault.sol
+++ b/contracts/insurance/InsuranceVault.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../bank/StrictBank.sol";
+
+// @title InsuranceVault
+// @dev Singleton vault that custodies per-market insurance reserves.
+// Per-market and per-token segregation is bookkeeping in DataStore via
+// insuranceFundBalanceKey(market, token); this contract holds the physical
+// ERC-20 balances. transferOut is gated by Bank's onlyController modifier.
+contract InsuranceVault is StrictBank {
+    constructor(RoleStore _roleStore, DataStore _dataStore) StrictBank(_roleStore, _dataStore) {}
+}

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -260,6 +260,63 @@ library MarketUtils {
         return poolAmount * tokenPrice;
     }
 
+    // @dev get the USD value of a pool excluding unrealized trader PnL.
+    // This mirrors getPoolValueInfo's pool-USD computation but skips the
+    // long/short PnL (`getCappedPnl`) deduction, so the value reflects only
+    // realized state plus borrowing-fee accruals minus the impact pool.
+    //
+    // Used by InsuranceFundUtils to snapshot the per-market USD value at
+    // epoch start and to compute the live drawdown fraction. Keeping both
+    // call sites on the same helper guarantees they share the exact same
+    // formula — otherwise a divergence between snapshot and live calc would
+    // surface as a phantom drawdown.
+    //
+    // Returns int256 to match getPoolValueInfo's return shape; in normal
+    // operation the value is non-negative, but in degenerate states the
+    // impact-pool deduction could in principle exceed the token + borrowing
+    // sum. Callers should treat negative returns as "zero pool value."
+    // @param dataStore DataStore
+    // @param market the market values
+    // @param prices the prices of the market tokens
+    // @param maximize whether to maximize or minimize the pool value
+    // @return the pool USD excluding unrealized trader PnL
+    function getPoolValueExcludingUnrealizedPnl(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketPrices memory prices,
+        bool maximize
+    ) internal view returns (int256) {
+        uint256 longTokenUsd = getPoolUsdWithoutPnl(dataStore, market, prices, true, maximize);
+        uint256 shortTokenUsd = getPoolUsdWithoutPnl(dataStore, market, prices, false, maximize);
+
+        int256 poolValue = (longTokenUsd + shortTokenUsd).toInt256();
+
+        uint256 totalBorrowingFees = getTotalPendingBorrowingFees(
+            dataStore,
+            market,
+            prices,
+            true
+        );
+
+        totalBorrowingFees += getTotalPendingBorrowingFees(
+            dataStore,
+            market,
+            prices,
+            false
+        );
+
+        uint256 borrowingFeePoolFactor = Precision.FLOAT_PRECISION - dataStore.getUint(Keys.BORROWING_FEE_RECEIVER_FACTOR);
+        poolValue += Precision.applyFactor(totalBorrowingFees, borrowingFeePoolFactor).toInt256();
+
+        uint256 impactPoolAmount = getNextPositionImpactPoolAmount(dataStore, market.marketToken);
+        // use !maximize for pickPrice since the impactPoolUsd is deducted from the poolValue
+        uint256 impactPoolUsd = impactPoolAmount * prices.indexTokenPrice.pickPrice(!maximize);
+
+        poolValue -= impactPoolUsd.toInt256();
+
+        return poolValue;
+    }
+
     // @dev get the USD value of a pool
     // the value of a pool is the worth of the liquidity provider tokens in the pool - pending trader pnl
     // we use the token index prices to calculate this and ignore price impact since if all positions were closed the

--- a/contracts/test/InsuranceFundUtilsTest.sol
+++ b/contracts/test/InsuranceFundUtilsTest.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../insurance/InsuranceFundUtils.sol";
+import "../insurance/InsuranceVault.sol";
+import "../market/Market.sol";
+import "../market/MarketUtils.sol";
+
+// @title InsuranceFundUtilsTest
+// @dev External test wrapper around the internal InsuranceFundUtils library
+// so unit tests can call its functions through the normal hardhat-ethers path.
+// Mirrors the MarketUtilsTest pattern.
+//
+// The deployed instance must be granted CONTROLLER role on RoleStore at test
+// setup so it can drive MarketToken.transferOut, vault.transferOut /
+// recordTransferIn, DataStore writes, and EventEmitter calls.
+contract InsuranceFundUtilsTest {
+    function getBalance(DataStore dataStore, address market, address token) external view returns (uint256) {
+        return InsuranceFundUtils.getBalance(dataStore, market, token);
+    }
+
+    function getDrawdownFraction(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external view returns (uint256, uint256, uint256) {
+        return InsuranceFundUtils.getDrawdownFraction(dataStore, market, prices);
+    }
+
+    function deposit(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount
+    ) external returns (uint256) {
+        return InsuranceFundUtils.deposit(dataStore, eventEmitter, vault, market, token, orderKey, amount);
+    }
+
+    function topUp(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount
+    ) external returns (uint256) {
+        return InsuranceFundUtils.topUp(dataStore, eventEmitter, vault, market, token, depositor, amount);
+    }
+
+    function attemptInjectPool(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        bytes32 orderKey
+    ) external returns (uint256) {
+        return InsuranceFundUtils.attemptInjectPool(dataStore, eventEmitter, vault, market, prices, pnlToken, orderKey);
+    }
+
+    function snapshotEpoch(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external returns (uint256) {
+        return InsuranceFundUtils.snapshotEpoch(dataStore, eventEmitter, market, prices);
+    }
+}

--- a/deploy/deployInsuranceFundEventUtils.ts
+++ b/deploy/deployInsuranceFundEventUtils.ts
@@ -1,0 +1,7 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const func = createDeployFunction({
+  contractName: "InsuranceFundEventUtils",
+});
+
+export default func;

--- a/deploy/deployInsuranceVault.ts
+++ b/deploy/deployInsuranceVault.ts
@@ -1,0 +1,14 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const constructorContracts = ["RoleStore", "DataStore"];
+
+const func = createDeployFunction({
+  contractName: "InsuranceVault",
+  dependencyNames: constructorContracts,
+  getDeployArgs: async ({ dependencyContracts }) => {
+    return constructorContracts.map((dependencyName) => dependencyContracts[dependencyName].address);
+  },
+  id: "InsuranceVault_1",
+});
+
+export default func;

--- a/test/insurance/InsuranceFundUtils.ts
+++ b/test/insurance/InsuranceFundUtils.ts
@@ -1,0 +1,277 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+import { deployContract } from "../../utils/deploy";
+import { deployFixture } from "../../utils/fixture";
+import { handleDeposit } from "../../utils/deposit";
+import { grantRole } from "../../utils/role";
+import { prices } from "../../utils/prices";
+import { expandDecimals, decimalToFloat, percentageToFloat } from "../../utils/math";
+import { parseLogs, getEventData } from "../../utils/event";
+import * as keys from "../../utils/keys";
+
+const MaxUint256 = hre.ethers.constants.MaxUint256;
+
+describe("InsuranceFundUtils", () => {
+  let fixture;
+  let wallet, user0;
+  let dataStore, eventEmitter, roleStore, insuranceVault, insuranceFundEventUtils;
+  let ethUsdMarket, wnt, usdc;
+  let testWrapper;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ wallet, user0 } = fixture.accounts);
+    ({ dataStore, eventEmitter, roleStore, insuranceVault, insuranceFundEventUtils, ethUsdMarket, wnt, usdc } =
+      fixture.contracts);
+
+    // Both event-util libraries are reachable through the inlined call chain:
+    // InsuranceFundUtils → MarketUtils.applyDeltaToPoolAmount → MarketEventUtils (external),
+    // and InsuranceFundUtils directly emits via InsuranceFundEventUtils.
+    const marketEventUtils = await hre.ethers.getContract("MarketEventUtils");
+    testWrapper = await deployContract("InsuranceFundUtilsTest", [], {
+      libraries: {
+        InsuranceFundEventUtils: insuranceFundEventUtils.address,
+        MarketEventUtils: marketEventUtils.address,
+      },
+    });
+
+    // CONTROLLER is checked in three places we hit through the wrapper:
+    //   - DataStore writes (applyDeltaToUint, setUint, incrementUint)
+    //   - MarketToken.transferOut (deposit path)
+    //   - InsuranceVault.transferOut / recordTransferIn / syncTokenBalance
+    //   - EventEmitter.emitEventLog*
+    // One CONTROLLER grant on the wrapper covers all of them.
+    await grantRole(roleStore, testWrapper.address, "CONTROLLER");
+
+    // Seed the LP pool so getPoolValueExcludingUnrealizedPnl returns non-zero.
+    // 1000 WETH @ $5000 = $5M long side; 1M USDC = $1M short side; pool = $6M.
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(1_000_000, 6),
+      },
+    });
+  });
+
+  it("getBalance returns 0 by default", async () => {
+    expect(await testWrapper.getBalance(dataStore.address, ethUsdMarket.marketToken, wnt.address)).eq(0);
+    expect(await testWrapper.getBalance(dataStore.address, ethUsdMarket.marketToken, usdc.address)).eq(0);
+  });
+
+  it("snapshotEpoch writes pool USD + timestamp and emits EpochReset", async () => {
+    const tx = await testWrapper.snapshotEpoch(
+      dataStore.address,
+      eventEmitter.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+    const receipt = await tx.wait();
+    const block = await hre.ethers.provider.getBlock(receipt.blockNumber);
+
+    const epochValue = await dataStore.getUint(keys.insuranceFundEpochPoolValueKey(ethUsdMarket.marketToken));
+    const epochStart = await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken));
+
+    // ~$6M scaled by 1e30, give or take borrowing accrual / impact pool which
+    // are zero in a fresh fixture.
+    expect(epochValue).gt(decimalToFloat(5_999_999));
+    expect(epochValue).lt(decimalToFloat(6_000_001));
+    expect(epochStart).eq(block.timestamp);
+
+    // Confirm event was emitted via EventEmitter (use the project's parseLogs helper)
+    const parsed = parseLogs(fixture, receipt);
+    const epochEvent = getEventData(parsed, "InsuranceFundEpochReset");
+    expect(epochEvent, "InsuranceFundEpochReset event missing").to.exist;
+    expect(epochEvent.market.toLowerCase()).eq(ethUsdMarket.marketToken.toLowerCase());
+    expect(epochEvent.epochPoolValue).eq(epochValue);
+    expect(epochEvent.timestamp).eq(epochStart);
+  });
+
+  it("getDrawdownFraction returns 0 when fund is disabled (no snapshot)", async () => {
+    const [drawdown, current, snap] = await testWrapper.getDrawdownFraction(
+      dataStore.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+    expect(drawdown).eq(0);
+    expect(snap).eq(0);
+    // current pool value should still be reported even when fund disabled
+    expect(current).gt(0);
+  });
+
+  it("getDrawdownFraction reflects realized pool drop after snapshot", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Simulate ~$500k realized PnL outflow by removing 100 WETH from the pool
+    // (100 * 5000 = 500k). At a snapshot of ~$6M, drawdown ~= 500k / 6M ~= 8.33%.
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    const [drawdown, current, snap] = await testWrapper.getDrawdownFraction(
+      dataStore.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+
+    expect(snap).gt(decimalToFloat(5_999_999));
+    expect(current).lt(snap);
+
+    // 500k / 6M ≈ 8.33% — allow a small band for borrowing/impact terms.
+    expect(drawdown).gt(percentageToFloat("8%"));
+    expect(drawdown).lt(percentageToFloat("9%"));
+  });
+
+  it("getDrawdownFraction returns 0 when epoch is stale", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Pool drop as before
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    // Enable stale check at 1 day, then advance time past it
+    await dataStore.setUint(keys.INSURANCE_FUND_MAX_EPOCH_AGE, 24 * 60 * 60);
+    await hre.network.provider.send("evm_increaseTime", [25 * 60 * 60]);
+    await hre.network.provider.send("evm_mine");
+
+    const [drawdown] = await testWrapper.getDrawdownFraction(dataStore.address, ethUsdMarket, prices.ethUsdMarket);
+    expect(drawdown).eq(0);
+  });
+
+  it("attemptInjectPool no-ops when triggerFactor is uint256.max", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    // Default for an unset key is 0, but the "off" sentinel is uint256.max.
+    // setUint accepts the max value.
+    await dataStore.setUint(keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken), MaxUint256);
+
+    expect(
+      await testWrapper.callStatic.attemptInjectPool(
+        dataStore.address,
+        eventEmitter.address,
+        insuranceVault.address,
+        ethUsdMarket,
+        prices.ethUsdMarket,
+        wnt.address,
+        hre.ethers.constants.HashZero
+      )
+    ).eq(0);
+  });
+
+  it("attemptInjectPool no-ops when drawdown is at/below trigger", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // 8.33% drawdown vs 10% trigger ⇒ no inject
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("10%")
+    );
+
+    expect(
+      await testWrapper.callStatic.attemptInjectPool(
+        dataStore.address,
+        eventEmitter.address,
+        insuranceVault.address,
+        ethUsdMarket,
+        prices.ethUsdMarket,
+        wnt.address,
+        hre.ethers.constants.HashZero
+      )
+    ).eq(0);
+  });
+
+  it("attemptInjectPool emits Shortfall when reserve bucket is empty", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Drop pool, set 2% trigger (drawdown ~= 8% > 2%)
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("2%")
+    );
+
+    const tx = await testWrapper.attemptInjectPool(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket,
+      prices.ethUsdMarket,
+      wnt.address,
+      hre.ethers.constants.HashZero
+    );
+    const receipt = await tx.wait();
+    const parsed = parseLogs(fixture, receipt);
+    const shortfall = getEventData(parsed, "InsuranceFundShortfall");
+    expect(shortfall, "InsuranceFundShortfall event missing").to.exist;
+    expect(shortfall.paid).eq(0);
+    expect(shortfall.requested).gt(0);
+
+    // No injection occurred — reserve and pool unchanged
+    expect(await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address))).eq(0);
+  });
+
+  it("attemptInjectPool injects to threshold when reserve is sufficient", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("2%")
+    );
+
+    // Pre-fund the vault with 200 WETH and tag the reserve bucket.
+    // Drawdown is ~$500k; covering down to 2% requires ~ (500k - 2%*6M) / 5000
+    // = (500k - 120k)/5000 = 76 WETH. 200 WETH is plenty.
+    const reserveAmount = expandDecimals(200, 18);
+    // Mint fresh WETH from the wallet's hardhat-default ETH balance — the
+    // fixture only deposits 50 WETH which is below our reserve target.
+    await wnt.connect(wallet).deposit({ value: reserveAmount });
+    await wnt.connect(wallet).transfer(insuranceVault.address, reserveAmount);
+    await insuranceVault.syncTokenBalance(wnt.address);
+    await dataStore.setUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address), reserveAmount);
+
+    const poolAmountBefore = await dataStore.getUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address));
+    const tx = await testWrapper.attemptInjectPool(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket,
+      prices.ethUsdMarket,
+      wnt.address,
+      hre.ethers.constants.HashZero
+    );
+    await tx.wait();
+
+    const poolAmountAfter = await dataStore.getUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address));
+    const reserveAfter = await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address));
+
+    // Pool should have grown; reserve should have shrunk by the same WETH amount.
+    expect(poolAmountAfter).gt(poolAmountBefore);
+    const injected = poolAmountAfter.sub(poolAmountBefore);
+    expect(reserveAfter).eq(reserveAmount.sub(injected));
+
+    // Post-injection drawdown should sit at or below the trigger.
+    const [drawdownAfter] = await testWrapper.getDrawdownFraction(dataStore.address, ethUsdMarket, prices.ethUsdMarket);
+    expect(drawdownAfter).lte(percentageToFloat("2%"));
+  });
+
+  it("deposit moves tokens from MarketToken to vault and increments reserve", async () => {
+    const amount = expandDecimals(5, 6); // 5 USDC
+
+    // The MarketToken side of the deposit needs USDC to move out of. The
+    // handleDeposit in beforeEach left 1M USDC sitting in ethUsdMarket.
+    const vaultUsdcBefore = await usdc.balanceOf(insuranceVault.address);
+
+    await testWrapper.deposit(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket.marketToken,
+      usdc.address,
+      hre.ethers.constants.HashZero,
+      amount
+    );
+
+    expect(await usdc.balanceOf(insuranceVault.address)).eq(vaultUsdcBefore.add(amount));
+    expect(await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, usdc.address))).eq(amount);
+  });
+});

--- a/utils/fixture.ts
+++ b/utils/fixture.ts
@@ -72,6 +72,8 @@ export async function deployFixture() {
   const eventEmitter = await hre.ethers.getContract("EventEmitter");
   const oracleStore = await hre.ethers.getContract("OracleStore");
   const orderVault = await hre.ethers.getContract("OrderVault");
+  const insuranceVault = await hre.ethers.getContract("InsuranceVault");
+  const insuranceFundEventUtils = await hre.ethers.getContract("InsuranceFundEventUtils");
   const glvVault = await hre.ethers.getContract("GlvVault");
   const marketFactory = await hre.ethers.getContract("MarketFactory");
   const glvFactory = await hre.ethers.getContract("GlvFactory");
@@ -265,6 +267,8 @@ export async function deployFixture() {
       shiftVault,
       oracleStore,
       orderVault,
+      insuranceVault,
+      insuranceFundEventUtils,
       marketFactory,
       depositHandler,
       depositUtils,

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -156,6 +156,16 @@ export const LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR = hashString("LIQUIDATION
 export const BORROWING_FEE_RECEIVER_FACTOR = hashString("BORROWING_FEE_RECEIVER_FACTOR");
 export const BORROWING_FEE_SECONDARY_RECEIVER_FACTOR = hashString("BORROWING_FEE_SECONDARY_RECEIVER_FACTOR");
 
+export const INSURANCE_VAULT = hashString("INSURANCE_VAULT");
+export const INSURANCE_FUND_FEE_FACTOR = hashString("INSURANCE_FUND_FEE_FACTOR");
+export const INSURANCE_FUND_POSITION_FEE_FACTOR = hashString("INSURANCE_FUND_POSITION_FEE_FACTOR");
+export const INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR = hashString("INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR");
+export const INSURANCE_FUND_BALANCE = hashString("INSURANCE_FUND_BALANCE");
+export const INSURANCE_FUND_EPOCH_POOL_VALUE = hashString("INSURANCE_FUND_EPOCH_POOL_VALUE");
+export const INSURANCE_FUND_EPOCH_START = hashString("INSURANCE_FUND_EPOCH_START");
+export const INSURANCE_FUND_MAX_EPOCH_AGE = hashString("INSURANCE_FUND_MAX_EPOCH_AGE");
+export const INSURANCE_FUND_EPOCH_LENGTH = hashString("INSURANCE_FUND_EPOCH_LENGTH");
+
 export const SWAP_FEE_FACTOR = hashString("SWAP_FEE_FACTOR");
 export const DEPOSIT_FEE_FACTOR = hashString("DEPOSIT_FEE_FACTOR");
 export const WITHDRAWAL_FEE_FACTOR = hashString("WITHDRAWAL_FEE_FACTOR");
@@ -600,6 +610,30 @@ export function proDiscountFactorKey(proTier: number) {
 
 export function liquidationFeeFactorKey(market: string) {
   return hashData(["bytes32", "address"], [LIQUIDATION_FEE_FACTOR, market]);
+}
+
+export function insuranceFundFeeFactorKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_FEE_FACTOR, market]);
+}
+
+export function insuranceFundPositionFeeFactorKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_POSITION_FEE_FACTOR, market]);
+}
+
+export function insuranceFundDrawdownTriggerFactorKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR, market]);
+}
+
+export function insuranceFundBalanceKey(market: string, token: string) {
+  return hashData(["bytes32", "address", "address"], [INSURANCE_FUND_BALANCE, market, token]);
+}
+
+export function insuranceFundEpochPoolValueKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_EPOCH_POOL_VALUE, market]);
+}
+
+export function insuranceFundEpochStartKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_EPOCH_START, market]);
 }
 
 export function latestAdlBlockKey(market: string, isLong: boolean) {


### PR DESCRIPTION
## Summary

Foundation for the per-market insurance fund described in the v1 design spec. Opened against `feat/insurance-fund-v1` — the long-lived integration target that follow-up sub-branches will stack into.

**Not yet operational.** This lands the data layer, vault, library, events, and a tested unit-test suite. The hooks that fire on a real trade (`processCollateral` collection + injection), `Config` registration, the `SettlementHandler`, and `Reader` getters are pending and ship in subsequent PRs into this same target branch.

## What's in

- **`contracts/data/Keys.sol`** — 8 constants (`INSURANCE_VAULT`, fee/trigger factors, balance, epoch snapshot/start, max-age, length) + 6 per-market key derivation helpers
- **`contracts/insurance/InsuranceVault.sol`** — singleton `StrictBank` extension. Per-(market, token) segregation is bookkeeping in DataStore
- **`contracts/insurance/InsuranceFundEventUtils.sol`** — 5 events: `Deposit`, `Injection`, `Shortfall`, `EpochReset`, `ManualDeposit` — routed through `EventEmitter`
- **`contracts/insurance/InsuranceFundUtils.sol`** — main library: `getBalance`, `getDrawdownFraction`, `deposit`, `topUp`, `attemptInjectPool`, `snapshotEpoch`
- **`contracts/market/MarketUtils.sol`** — `getPoolValueExcludingUnrealizedPnl` aggregator composing the existing per-side `getPoolUsdWithoutPnl` + borrowing-fee + impact-pool terms
- **`contracts/test/InsuranceFundUtilsTest.sol`** — external wrapper exposing the internal library for unit tests
- Deploy scripts for vault and event utils; `utils/keys.ts` and `utils/fixture.ts` updates for tests
- **`test/insurance/InsuranceFundUtils.ts`** — 10 unit tests, all passing

## Design notes (vs. spec)

- **Vault wiring** uses DataStore-resolved `Keys.INSURANCE_VAULT` instead of constructor-injected — libraries can't hold immutable state, so the spec's constructor-injection approach can't work for the library-driven injection path. Matches the `HOLDING_ADDRESS` precedent.
- **`INSURANCE_FUND_POSITION_FEE_FACTOR` added** beyond spec. The spec collects only from `liquidationFeeAmount`, but liquidation-fee collection is skipped on insolvent liquidations (`DecreasePositionCollateralUtils.handleEarlyReturn`) — exactly when the fund is most needed. The position-fee slice keeps the fund accruing in calm markets too.
- **`type(uint256).max` is the disabled-trigger sentinel**, not zero. Zero semantically means "inject on any drawdown."
- **Renamed the `Drawdown` event to `Shortfall`** — the design uses "drawdown" for pool decline; reusing the term for the event was confusing.

## Test plan

- [x] `npx hardhat compile` — clean
- [x] `npx hardhat test test/insurance/InsuranceFundUtils.ts` — 10/10 passing
- [ ] Integration tests deferred until `processCollateral` is wired in a follow-up PR

## Out of scope

- Subsquid indexer additions — separate repo (`0xMarkets-squid`)
- Frontend display — separate repo (`0xMarkets-Interface`)

## Pending follow-up PRs (into this same target branch)

1. `PositionPricingUtils` extensions (struct + `getLiquidationFees` insurance slice + position-fee slice + `feeAmountForPool` arithmetic fix)
2. `processCollateral` hooks (collection transfer + end-of-function `attemptInjectPool`)
3. `Config` registration in `_initAllowedBaseKeys` + sum-of-shares invariant + conservative cap on global liquidation factors
4. `SettlementHandler` contract + `snapshotEpoch(market[])` keeper
5. `Reader` getters for dashboards