### PR TITLE
Per-market insurance fund v1,  LP protection via fee-funded reserves

### DIFF
--- a/contracts/config/ConfigAllowedKeys.sol
+++ b/contracts/config/ConfigAllowedKeys.sol
@@ -89,6 +89,16 @@ library ConfigAllowedKeys {
         allowedBaseKeys[Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR] = true;
         allowedBaseKeys[Keys.LIQUIDATION_FEE_INSURANCE_FACTOR] = true;
 
+        // Insurance fund — governance-tunable parameters.
+        // INSURANCE_FUND_ADDRESS and LIQUIDATION_FEE_INSURANCE_FACTOR are registered
+        // above by fee-addresses (PR #31). Storage keys for the fund (balance, epoch
+        // snapshot, epoch start) are NOT registered here: balances are written by
+        // InsuranceFundUtils on each close + snapshot, not by governance. Those
+        // keys live in EXCLUDED_CONFIG_KEYS in utils/config.ts.
+        allowedBaseKeys[Keys.INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR] = true;
+        allowedBaseKeys[Keys.INSURANCE_FUND_MAX_EPOCH_AGE] = true;
+        allowedBaseKeys[Keys.INSURANCE_FUND_EPOCH_LENGTH] = true;
+
         allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1] = true;
         allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_PER_ORACLE_PRICE] = true;
         allowedBaseKeys[Keys.ESTIMATED_GAS_FEE_MULTIPLIER_FACTOR] = true;

--- a/contracts/config/ConfigValidatorUtils.sol
+++ b/contracts/config/ConfigValidatorUtils.sol
@@ -164,5 +164,38 @@ library ConfigValidatorUtils {
                 revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
             }
         }
+
+        // ---------------------------------------------------------------
+        // Insurance fund — sum-of-shares + drawdown trigger bounds
+        // ---------------------------------------------------------------
+        //
+        // The liquidation fee is split between validator + insurance + pool.
+        // PositionPricingUtils.getPositionFees computes the pool share as
+        // residual: liquidationFeeAmount - liquidationFeeAmountForValidator -
+        // liquidationFeeAmountForInsurance. Validator + insurance > 1e30
+        // would underflow that subtraction, so enforce the sum here.
+        // Both factors are global, so this check is exact (no per-market scope
+        // ambiguity).
+        if (
+            baseKey == Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR ||
+            baseKey == Keys.LIQUIDATION_FEE_INSURANCE_FACTOR
+        ) {
+            bytes32 otherKey = baseKey == Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR
+                ? Keys.LIQUIDATION_FEE_INSURANCE_FACTOR
+                : Keys.LIQUIDATION_FEE_VALIDATOR_FACTOR;
+            uint256 otherValue = dataStore.getUint(otherKey);
+            if (value + otherValue > Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
+        // Drawdown trigger factor: type(uint256).max is the off-sentinel
+        // (operators set this to disable the fund on a market). Otherwise
+        // value must be ≤ 100% so the threshold is a fraction of pool USD.
+        if (baseKey == Keys.INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR) {
+            if (value != type(uint256).max && value > Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
     }
 }

--- a/contracts/data/Keys.sol
+++ b/contracts/data/Keys.sol
@@ -219,6 +219,25 @@ library Keys {
     // @dev key for the share of liquidation fees routed to the insurance fund
     bytes32 public constant LIQUIDATION_FEE_INSURANCE_FACTOR = keccak256(abi.encode("LIQUIDATION_FEE_INSURANCE_FACTOR"));
 
+    // @dev per-market realized-drawdown threshold; InsuranceFundUtils.attemptInjectPool
+    // moves reserves back into the pool when drawdown crosses this.
+    // type(uint256).max is the off-sentinel.
+    bytes32 public constant INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR = keccak256(abi.encode("INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR"));
+    // @dev per (market, token) insurance reserve balance. Tokens physically held by the
+    // InsuranceVault singleton (resolved via INSURANCE_FUND_ADDRESS); this DataStore
+    // entry is bookkeeping segregating reserves by market+token.
+    // Invariant: InsuranceVault.tokenBalances(token) >= sum across markets of insuranceFundBalanceKey(market, token).
+    bytes32 public constant INSURANCE_FUND_BALANCE = keccak256(abi.encode("INSURANCE_FUND_BALANCE"));
+    // @dev per-market USD snapshot of poolValueExcludingUnrealizedPnl at the last epoch start.
+    bytes32 public constant INSURANCE_FUND_EPOCH_POOL_VALUE = keccak256(abi.encode("INSURANCE_FUND_EPOCH_POOL_VALUE"));
+    // @dev per-market timestamp of the last epoch start. Treat the fund as disabled
+    // when this is zero (first epoch) or older than INSURANCE_FUND_MAX_EPOCH_AGE.
+    bytes32 public constant INSURANCE_FUND_EPOCH_START = keccak256(abi.encode("INSURANCE_FUND_EPOCH_START"));
+    // @dev maximum allowed age of an epoch snapshot before the fund auto-disables (global, seconds).
+    bytes32 public constant INSURANCE_FUND_MAX_EPOCH_AGE = keccak256(abi.encode("INSURANCE_FUND_MAX_EPOCH_AGE"));
+    // @dev epoch length used by SettlementHandler.snapshotEpoch idempotency guard (global, seconds).
+    bytes32 public constant INSURANCE_FUND_EPOCH_LENGTH = keccak256(abi.encode("INSURANCE_FUND_EPOCH_LENGTH"));
+
     // @dev key for the base gas limit used when estimating execution fee
     bytes32 public constant ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1 = keccak256(abi.encode("ESTIMATED_GAS_FEE_BASE_AMOUNT_V2_1"));
     // @dev key for the gas limit used for each oracle price when estimating execution fee
@@ -1250,6 +1269,39 @@ library Keys {
     function liquidationFeeFactorKey(address market) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             LIQUIDATION_FEE_FACTOR,
+            market
+        ));
+    }
+
+    // @dev per-market drawdown trigger threshold
+    function insuranceFundDrawdownTriggerFactorKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR,
+            market
+        ));
+    }
+
+    // @dev per (market, token) insurance reserve balance
+    function insuranceFundBalanceKey(address market, address token) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_BALANCE,
+            market,
+            token
+        ));
+    }
+
+    // @dev per-market USD pool-value snapshot at last epoch start
+    function insuranceFundEpochPoolValueKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_EPOCH_POOL_VALUE,
+            market
+        ));
+    }
+
+    // @dev per-market timestamp of the last epoch start
+    function insuranceFundEpochStartKey(address market) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            INSURANCE_FUND_EPOCH_START,
             market
         ));
     }

--- a/contracts/error/Errors.sol
+++ b/contracts/error/Errors.sol
@@ -382,6 +382,9 @@ library Errors {
     error EmptyAccount();
     error EmptyReceiver();
 
+    // InsuranceFund errors
+    error InsuranceFundEpochNotYetElapsed(uint256 currentTime, uint256 epochStart, uint256 epochLength);
+
     // Array errors
     error CompactedArrayOutOfBounds(
         uint256[] compactedValues,

--- a/contracts/insurance/InsuranceFundEventUtils.sol
+++ b/contracts/insurance/InsuranceFundEventUtils.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../event/EventEmitter.sol";
+import "../event/EventUtils.sol";
+import "../utils/Cast.sol";
+
+// @title InsuranceFundEventUtils
+// @dev Emits the per-action events for the insurance fund.
+// Mirrors the MarketEventUtils style so the subsquid indexer can pick these
+// up with the same EventEmitter routing.
+library InsuranceFundEventUtils {
+    using EventUtils for EventUtils.AddressItems;
+    using EventUtils for EventUtils.UintItems;
+    using EventUtils for EventUtils.IntItems;
+    using EventUtils for EventUtils.BoolItems;
+    using EventUtils for EventUtils.Bytes32Items;
+    using EventUtils for EventUtils.BytesItems;
+    using EventUtils for EventUtils.StringItems;
+
+    // Emitted when the per-close liquidation/position-fee slice is moved from
+    // MarketToken into the InsuranceVault and the reserve bucket is incremented.
+    function emitInsuranceFundDeposit(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount,
+        uint256 newBalance
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newBalance", newBalance);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundDeposit",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when reserves are transferred from the InsuranceVault into MarketToken
+    // and credited to the pool via applyDeltaToPoolAmount.
+    function emitInsuranceFundInjection(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount,
+        uint256 newPoolAmount,
+        uint256 newReserveBalance,
+        uint256 drawdownBefore,
+        uint256 drawdownAfter
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(5);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newPoolAmount", newPoolAmount);
+        eventData.uintItems.setItem(2, "newReserveBalance", newReserveBalance);
+        eventData.uintItems.setItem(3, "drawdownBefore", drawdownBefore);
+        eventData.uintItems.setItem(4, "drawdownAfter", drawdownAfter);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundInjection",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when an injection was requested but the (market, token) reserve
+    // could not cover the full amount. paid == 0 means nothing was injected.
+    // Distinct from InsuranceFundInjection because operators alert on this:
+    // a recurring shortfall means the reserve is undersized for the market.
+    function emitInsuranceFundShortfall(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 requested,
+        uint256 paid
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(2);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+
+        eventData.bytes32Items.initItems(1);
+        eventData.bytes32Items.setItem(0, "orderKey", orderKey);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "requested", requested);
+        eventData.uintItems.setItem(1, "paid", paid);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundShortfall",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted when SettlementHandler snapshots pool value at epoch start.
+    function emitInsuranceFundEpochReset(
+        EventEmitter eventEmitter,
+        address market,
+        uint256 epochPoolValue,
+        uint256 timestamp
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(1);
+        eventData.addressItems.setItem(0, "market", market);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "epochPoolValue", epochPoolValue);
+        eventData.uintItems.setItem(1, "timestamp", timestamp);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundEpochReset",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+
+    // Emitted on governance-initiated topUp from treasury (out-of-band seeding).
+    function emitInsuranceFundManualDeposit(
+        EventEmitter eventEmitter,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount,
+        uint256 newBalance
+    ) external {
+        EventUtils.EventLogData memory eventData;
+
+        eventData.addressItems.initItems(3);
+        eventData.addressItems.setItem(0, "market", market);
+        eventData.addressItems.setItem(1, "token", token);
+        eventData.addressItems.setItem(2, "depositor", depositor);
+
+        eventData.uintItems.initItems(2);
+        eventData.uintItems.setItem(0, "amount", amount);
+        eventData.uintItems.setItem(1, "newBalance", newBalance);
+
+        eventEmitter.emitEventLog1(
+            "InsuranceFundManualDeposit",
+            Cast.toBytes32(market),
+            eventData
+        );
+    }
+}

--- a/contracts/insurance/InsuranceFundUtils.sol
+++ b/contracts/insurance/InsuranceFundUtils.sol
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-v4/utils/math/SafeCast.sol";
+
+import "../data/DataStore.sol";
+import "../data/Keys.sol";
+import "../event/EventEmitter.sol";
+import "../market/Market.sol";
+import "../market/MarketToken.sol";
+import "../market/MarketUtils.sol";
+import "../price/Price.sol";
+import "../utils/Precision.sol";
+
+import "./InsuranceVault.sol";
+import "./InsuranceFundEventUtils.sol";
+
+// @title InsuranceFundUtils
+// @dev Per-market insurance reserve logic. Three responsibilities:
+//   1. Collect a configurable slice of liquidation/position fees into the
+//      InsuranceVault (deposit).
+//   2. Inject capital from the vault back into MarketToken when realized
+//      pool drawdown exceeds the per-market trigger threshold
+//      (attemptInjectPool).
+//   3. Snapshot the per-market pool USD value at epoch boundaries so
+//      drawdown can be computed against a stable baseline (snapshotEpoch).
+//
+// The vault is a singleton; per-market and per-token segregation is
+// bookkeeping in DataStore. Callers must already hold the CONTROLLER role
+// on MarketToken and the InsuranceVault — the protocol handlers do.
+library InsuranceFundUtils {
+    using SafeCast for int256;
+    using SafeCast for uint256;
+
+    using Price for Price.Props;
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    function getBalance(DataStore dataStore, address market, address token) internal view returns (uint256) {
+        return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+    }
+
+    // @dev Computes the current realized drawdown fraction for a market.
+    //
+    // Returns (0, currentValue, epochValue) when the fund is **disabled**
+    // for that market, which is any of:
+    //   - first epoch (epochValue == 0, snapshotEpoch never ran)
+    //   - stale snapshot (block.timestamp - epochStart > MAX_EPOCH_AGE)
+    //   - pool currently at or above the epoch snapshot (no drawdown)
+    //
+    // Uses minimize=false for the pool-value lookup so the snapshot and
+    // current measurement use the same price-pick rule. Both use the LP-
+    // conservative "minimize" pickPrice so a stressed-LP read is always
+    // the larger number (better protection).
+    function getDrawdownFraction(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) public view returns (uint256 drawdownFraction, uint256 currentPoolValueUsd, uint256 epochPoolValueUsd) {
+        int256 cur = MarketUtils.getPoolValueExcludingUnrealizedPnl(dataStore, market, prices, false);
+        currentPoolValueUsd = cur < 0 ? 0 : uint256(cur);
+
+        epochPoolValueUsd = dataStore.getUint(Keys.insuranceFundEpochPoolValueKey(market.marketToken));
+        if (epochPoolValueUsd == 0) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        uint256 epochStart = dataStore.getUint(Keys.insuranceFundEpochStartKey(market.marketToken));
+        uint256 maxAge = dataStore.getUint(Keys.INSURANCE_FUND_MAX_EPOCH_AGE);
+        // maxAge == 0 disables the stale check (treat as no upper bound).
+        // A keeper-supplied maxAge of e.g. 8 days bounds how long a missed
+        // Friday snapshot can poison subsequent drawdown calculations.
+        if (maxAge > 0 && epochStart != 0 && block.timestamp - epochStart > maxAge) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        if (currentPoolValueUsd >= epochPoolValueUsd) {
+            return (0, currentPoolValueUsd, epochPoolValueUsd);
+        }
+
+        uint256 drawdownUsd = epochPoolValueUsd - currentPoolValueUsd;
+        // 1e30-scaled fraction. epochPoolValueUsd is non-zero by the check above.
+        drawdownFraction = (drawdownUsd * Precision.FLOAT_PRECISION) / epochPoolValueUsd;
+    }
+
+    // ---------------------------------------------------------------------
+    // Collection
+    // ---------------------------------------------------------------------
+
+    // @dev Moves `amount` of `token` from MarketToken into the InsuranceVault
+    // and increments the per (market, token) reserve bookkeeping.
+    //
+    // Idempotent on zero (no-op rather than revert) so callers can pass the
+    // computed slice unconditionally without an outer check.
+    function deposit(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount
+    ) external returns (uint256 newBalance) {
+        if (amount == 0) {
+            return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+        }
+
+        MarketToken(payable(market)).transferOut(token, address(vault), amount);
+        // recordTransferIn returns the delta vs. previously-tracked balance.
+        // We ignore the return value because the bookkeeping increment uses
+        // the requested `amount`; if a non-standard token (fee-on-transfer)
+        // delivered less, the invariant
+        //   vault.tokenBalances(token) >= sum(reserve buckets)
+        // would fail, which is the correct posture — we don't support such
+        // tokens as pnl/collateral in any market.
+        vault.recordTransferIn(token);
+
+        newBalance = dataStore.incrementUint(Keys.insuranceFundBalanceKey(market, token), amount);
+
+        InsuranceFundEventUtils.emitInsuranceFundDeposit(
+            eventEmitter,
+            market,
+            token,
+            orderKey,
+            amount,
+            newBalance
+        );
+    }
+
+    // @dev Governance-initiated reserve top-up from treasury.
+    //
+    // Two-phase: external caller must first transfer `amount` of `token`
+    // into the vault, then call this to record the transfer and increment
+    // the bucket. Mirrors the protocol's "send then record" pattern (see
+    // ExchangeRouter deposits).
+    function topUp(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount
+    ) internal returns (uint256 newBalance) {
+        if (amount == 0) {
+            return dataStore.getUint(Keys.insuranceFundBalanceKey(market, token));
+        }
+
+        // recordTransferIn reads balanceOf and subtracts the prior cached
+        // value; reverts implicitly if the depositor under-transferred.
+        uint256 received = vault.recordTransferIn(token);
+        require(received >= amount, "InsuranceFundUtils: under-funded topUp");
+
+        newBalance = dataStore.incrementUint(Keys.insuranceFundBalanceKey(market, token), amount);
+
+        InsuranceFundEventUtils.emitInsuranceFundManualDeposit(
+            eventEmitter,
+            market,
+            token,
+            depositor,
+            amount,
+            newBalance
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Injection
+    // ---------------------------------------------------------------------
+
+    // @dev If realized drawdown exceeds the per-market trigger factor,
+    // transfers `pnlToken` from the InsuranceVault into MarketToken and
+    // credits the pool via applyDeltaToPoolAmount until drawdown returns
+    // to threshold (or the reserve bucket is drained).
+    //
+    // Returns the number of tokens actually injected (0 if no trigger or
+    // empty reserve). Never reverts on insufficient reserve — emits
+    // InsuranceFundShortfall and proceeds.
+    //
+    // Wiring: this is intended to be called once at the end of
+    // DecreasePositionCollateralUtils.processCollateral, after all
+    // applyDeltaToPoolAmount branches have settled. ADL and liquidation
+    // paths flow through the same `processCollateral`, so they pick this
+    // up automatically.
+    function attemptInjectPool(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        bytes32 orderKey
+    ) external returns (uint256 injectedAmount) {
+        uint256 triggerFactor = dataStore.getUint(Keys.insuranceFundDrawdownTriggerFactorKey(market.marketToken));
+        // type(uint256).max is the "off" sentinel; default value of an unset
+        // key is 0, which would semantically mean "inject on any drawdown",
+        // so the unset-by-default state is the wrong direction. Operators
+        // must explicitly set type(uint256).max in Config to mark a market
+        // as not-yet-onboarded. (Spec §4.1 lists this as the default; the
+        // deploy script must initialize accordingly.)
+        if (triggerFactor == type(uint256).max) {
+            return 0;
+        }
+
+        uint256 drawdownBefore;
+        uint256 requestedTokens;
+        {
+            (uint256 _drawdownBefore, uint256 currentValue, uint256 epochValue) = getDrawdownFraction(dataStore, market, prices);
+            if (_drawdownBefore <= triggerFactor) {
+                return 0;
+            }
+            drawdownBefore = _drawdownBefore;
+            requestedTokens = _computeRequestedInjection(
+                market,
+                prices,
+                pnlToken,
+                currentValue,
+                epochValue,
+                triggerFactor
+            );
+            if (requestedTokens == 0) {
+                return 0;
+            }
+        }
+
+        uint256 reserveBalance = dataStore.getUint(Keys.insuranceFundBalanceKey(market.marketToken, pnlToken));
+        if (reserveBalance == 0) {
+            InsuranceFundEventUtils.emitInsuranceFundShortfall(
+                eventEmitter,
+                market.marketToken,
+                pnlToken,
+                orderKey,
+                requestedTokens,
+                0
+            );
+            return 0;
+        }
+
+        injectedAmount = requestedTokens > reserveBalance ? reserveBalance : requestedTokens;
+
+        // Physical move vault → marketToken. The vault's _afterTransferOut
+        // hook (StrictBank) re-syncs its tokenBalances mapping.
+        vault.transferOut(pnlToken, market.marketToken, injectedAmount);
+
+        // Pool accounting credit. Also tweaks virtual swap inventory as a
+        // side-effect inside applyDeltaToPoolAmount — see review §1.6.
+        uint256 newPoolAmount = MarketUtils.applyDeltaToPoolAmount(
+            dataStore,
+            eventEmitter,
+            market,
+            pnlToken,
+            injectedAmount.toInt256()
+        );
+
+        // Decrement the reserve bucket.
+        uint256 newReserveBalance = dataStore.applyDeltaToUint(
+            Keys.insuranceFundBalanceKey(market.marketToken, pnlToken),
+            -injectedAmount.toInt256(),
+            "Invalid state, negative insurance reserve"
+        );
+
+        // Recompute drawdown post-injection for the event payload. Cheaper
+        // alternatives exist (subtract injectedAmount*price/epochValue from
+        // drawdownBefore) but a fresh read is robust against any concurrent
+        // pool-amount changes within this tx.
+        (uint256 drawdownAfter, , ) = getDrawdownFraction(dataStore, market, prices);
+
+        InsuranceFundEventUtils.emitInsuranceFundInjection(
+            eventEmitter,
+            market.marketToken,
+            pnlToken,
+            orderKey,
+            injectedAmount,
+            newPoolAmount,
+            newReserveBalance,
+            drawdownBefore,
+            drawdownAfter
+        );
+
+        if (injectedAmount < requestedTokens) {
+            InsuranceFundEventUtils.emitInsuranceFundShortfall(
+                eventEmitter,
+                market.marketToken,
+                pnlToken,
+                orderKey,
+                requestedTokens,
+                injectedAmount
+            );
+        }
+    }
+
+    // @dev Compute the number of pnlToken units needed to bring drawdown
+    // back to threshold. Extracted from attemptInjectPool so the
+    // intermediate locals (target, missing, pnlTokenPrice) don't pin slots
+    // on the caller's stack — stack-too-deep otherwise.
+    function _computeRequestedInjection(
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        uint256 currentValue,
+        uint256 epochValue,
+        uint256 triggerFactor
+    ) private pure returns (uint256) {
+        uint256 targetCurrentValue = Precision.applyFactor(
+            epochValue,
+            Precision.FLOAT_PRECISION - triggerFactor
+        );
+        // drawdownBefore > triggerFactor (caller checked) ⇒ currentValue < targetCurrentValue.
+        uint256 missingUsd = targetCurrentValue - currentValue;
+
+        // Use pnlTokenPrice.min so we slightly over-inject (LP-favorable rounding).
+        Price.Props memory pnlTokenPrice = MarketUtils.getCachedTokenPrice(pnlToken, market, prices);
+        return missingUsd / pnlTokenPrice.min;
+    }
+
+    // ---------------------------------------------------------------------
+    // Epoch lifecycle
+    // ---------------------------------------------------------------------
+
+    // @dev Snapshots the current pool USD (excluding unrealized PnL) as the
+    // baseline for the next epoch's drawdown calculation, and stamps the
+    // epoch-start timestamp.
+    //
+    // Idempotency / freshness is the caller's concern — SettlementHandler
+    // enforces an epoch-length gap. This function unconditionally writes.
+    function snapshotEpoch(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external returns (uint256 epochValue) {
+        // minimize=false matches getDrawdownFraction's call so both sides
+        // use the same price-pick rule. (Snapshot pick must match current
+        // pick or drawdown will mis-fire.)
+        int256 poolValue = MarketUtils.getPoolValueExcludingUnrealizedPnl(dataStore, market, prices, false);
+        epochValue = poolValue < 0 ? 0 : uint256(poolValue);
+
+        dataStore.setUint(Keys.insuranceFundEpochPoolValueKey(market.marketToken), epochValue);
+        dataStore.setUint(Keys.insuranceFundEpochStartKey(market.marketToken), block.timestamp);
+
+        InsuranceFundEventUtils.emitInsuranceFundEpochReset(
+            eventEmitter,
+            market.marketToken,
+            epochValue,
+            block.timestamp
+        );
+    }
+}

--- a/contracts/insurance/InsuranceVault.sol
+++ b/contracts/insurance/InsuranceVault.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../bank/StrictBank.sol";
+
+// @title InsuranceVault
+// @dev Singleton vault that custodies per-market insurance reserves.
+// Per-market and per-token segregation is bookkeeping in DataStore via
+// insuranceFundBalanceKey(market, token); this contract holds the physical
+// ERC-20 balances. transferOut is gated by Bank's onlyController modifier.
+contract InsuranceVault is StrictBank {
+    constructor(RoleStore _roleStore, DataStore _dataStore) StrictBank(_roleStore, _dataStore) {}
+}

--- a/contracts/insurance/SettlementHandler.sol
+++ b/contracts/insurance/SettlementHandler.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../exchange/BaseHandler.sol";
+import "../market/MarketStoreUtils.sol";
+import "../market/MarketUtils.sol";
+
+import "./InsuranceFundUtils.sol";
+
+// @title SettlementHandler
+// @dev Permissioned keeper entrypoint for the insurance fund's epoch lifecycle.
+// Today the only operation is per-market snapshot of pool USD (excluding
+// unrealized PnL) at the start of each epoch — drawdown calculations downstream
+// compare live state against this snapshot.
+//
+// Keeper expectation: call `snapshotEpoch(market, oracleParams)` once per market
+// at each Friday 00:00 UTC boundary. The function is idempotent within an
+// epoch — if `INSURANCE_FUND_EPOCH_LENGTH` seconds have not elapsed since the
+// last snapshot it reverts with `InsuranceFundEpochNotYetElapsed`. First call
+// on a market (epochStart == 0) is always allowed.
+contract SettlementHandler is BaseHandler {
+    constructor(
+        RoleStore _roleStore,
+        DataStore _dataStore,
+        EventEmitter _eventEmitter,
+        Oracle _oracle
+    ) BaseHandler(_roleStore, _dataStore, _eventEmitter, _oracle) {}
+
+    // @param market the market to snapshot
+    // @param oracleParams oracle prices payload — must include the market's
+    //        indexToken / longToken / shortToken so getMarketPrices resolves
+    function snapshotEpoch(
+        address market,
+        OracleUtils.SetPricesParams calldata oracleParams
+    ) external
+        globalNonReentrant
+        onlyOrderKeeper
+        withOraclePrices(oracleParams)
+    {
+        uint256 epochStart = dataStore.getUint(Keys.insuranceFundEpochStartKey(market));
+        uint256 epochLength = dataStore.getUint(Keys.INSURANCE_FUND_EPOCH_LENGTH);
+
+        // Idempotency guard: allow if first-ever snapshot (epochStart == 0) or
+        // if epoch length has elapsed since last snap. Skipping this would let
+        // a keeper rewrite the snapshot mid-epoch and reset drawdown to zero,
+        // defeating the LP protection.
+        if (epochStart != 0 && block.timestamp < epochStart + epochLength) {
+            revert Errors.InsuranceFundEpochNotYetElapsed(block.timestamp, epochStart, epochLength);
+        }
+
+        Market.Props memory marketProps = MarketStoreUtils.get(dataStore, market);
+        MarketUtils.MarketPrices memory marketPrices = MarketUtils.getMarketPrices(oracle, marketProps);
+
+        InsuranceFundUtils.snapshotEpoch(dataStore, eventEmitter, marketProps, marketPrices);
+    }
+}

--- a/contracts/market/MarketUtils.sol
+++ b/contracts/market/MarketUtils.sol
@@ -260,6 +260,47 @@ library MarketUtils {
         return poolAmount * tokenPrice;
     }
 
+    // @dev get the USD value of a pool excluding unrealized trader PnL.
+    // Mirrors getPoolValueInfo's pool-USD computation but skips the long/short
+    // PnL (`getCappedPnl`) deduction, so the value reflects only realized state
+    // plus borrowing-fee accruals minus the impact pool.
+    //
+    // Used by InsuranceFundUtils to snapshot the per-market USD value at epoch
+    // start and to compute the live drawdown fraction. Keeping both call sites
+    // on the same helper guarantees they share the exact same formula —
+    // otherwise a divergence would surface as phantom drawdown.
+    //
+    // Returns int256 to match getPoolValueInfo's return shape; in normal
+    // operation the value is non-negative, but in degenerate states the
+    // impact-pool deduction could exceed the token + borrowing sum. Callers
+    // should treat negative returns as "zero pool value."
+    function getPoolValueExcludingUnrealizedPnl(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketPrices memory prices,
+        bool maximize
+    ) internal view returns (int256) {
+        uint256 longTokenUsd = getPoolUsdWithoutPnl(dataStore, market, prices, true, maximize);
+        uint256 shortTokenUsd = getPoolUsdWithoutPnl(dataStore, market, prices, false, maximize);
+
+        int256 poolValue = (longTokenUsd + shortTokenUsd).toInt256();
+
+        uint256 totalBorrowingFees = getTotalPendingBorrowingFees(dataStore, market, prices, true);
+        totalBorrowingFees += getTotalPendingBorrowingFees(dataStore, market, prices, false);
+
+        // Post-fee-addresses (PR #31): borrowing fees go 100% to the pool, no
+        // receiver factor — mirror that here so the snapshot matches getPoolValueInfo.
+        poolValue += totalBorrowingFees.toInt256();
+
+        uint256 impactPoolAmount = getNextPositionImpactPoolAmount(dataStore, market.marketToken);
+        // use !maximize for pickPrice since the impactPoolUsd is deducted from the poolValue
+        uint256 impactPoolUsd = impactPoolAmount * prices.indexTokenPrice.pickPrice(!maximize);
+
+        poolValue -= impactPoolUsd.toInt256();
+
+        return poolValue;
+    }
+
     // @dev get the USD value of a pool
     // the value of a pool is the worth of the liquidity provider tokens in the pool - pending trader pnl
     // we use the token index prices to calculate this and ignore price impact since if all positions were closed the

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -17,6 +17,9 @@ import "../order/OrderEventUtils.sol";
 
 import "./DecreasePositionSwapUtils.sol";
 
+import "../insurance/InsuranceFundUtils.sol";
+import "../insurance/InsuranceVault.sol";
+
 // @title DecreasePositionCollateralUtils
 // @dev Library for functions to help with the calculations when decreasing a position
 library DecreasePositionCollateralUtils {
@@ -514,7 +517,37 @@ library DecreasePositionCollateralUtils {
             values.output.outputAmount += params.order.initialCollateralDeltaAmount();
         }
 
+        // Insurance fund: see _maybeInjectInsurancePool. Extracted to a private
+        // helper to keep processCollateral under the stack-depth limit; the
+        // helper's locals don't pin slots in the parent.
+        _maybeInjectInsurancePool(params, cache);
+
         return (values, fees);
+    }
+
+    // @dev If realized drawdown exceeds the per-market trigger factor, move
+    // reserves from the InsuranceVault back into the pool. No-ops cleanly when
+    // the trigger is the off-sentinel (type(uint256).max), drawdown is at or
+    // below the threshold, the epoch snapshot is stale/uninitialized, or
+    // INSURANCE_FUND_ADDRESS is unset. ADL and liquidation paths flow through
+    // the same processCollateral and pick this up automatically.
+    function _maybeInjectInsurancePool(
+        PositionUtils.UpdatePositionParams memory params,
+        PositionUtils.DecreasePositionCache memory cache
+    ) private {
+        address vaultAddress = params.contracts.dataStore.getAddress(Keys.INSURANCE_FUND_ADDRESS);
+        if (vaultAddress == address(0)) {
+            return;
+        }
+        InsuranceFundUtils.attemptInjectPool(
+            params.contracts.dataStore,
+            params.contracts.eventEmitter,
+            InsuranceVault(payable(vaultAddress)),
+            params.market,
+            cache.prices,
+            cache.pnlToken,
+            params.orderKey
+        );
     }
 
     function payForCost(
@@ -762,17 +795,26 @@ library DecreasePositionCollateralUtils {
             );
         }
 
-        address insuranceFundAddress = params.contracts.dataStore.getAddress(Keys.INSURANCE_FUND_ADDRESS);
-        if (insuranceFundAddress != address(0)) {
-            FeeUtils.incrementClaimableFeeAmount(
-                params.contracts.dataStore,
-                params.contracts.eventEmitter,
-                insuranceFundAddress,
-                params.market.marketToken,
-                collateralToken,
-                fees.insuranceFeeAmount,
-                Keys.POSITION_FEE_TYPE
-            );
+        // Insurance fund: route the configured slice into the InsuranceVault.
+        // INSURANCE_FUND_ADDRESS holds the vault contract; InsuranceFundUtils.deposit
+        // transfers the slice from MarketToken into the vault and increments the
+        // per (market, token) reserve bucket so attemptInjectPool can draw from it
+        // when realized drawdown crosses the trigger. fees.feeAmountForPool already
+        // excludes this slice (see PositionPricingUtils.getPositionFees) — no
+        // double counting against the pool delta.
+        if (fees.insuranceFeeAmount > 0) {
+            InsuranceVault insuranceVault = InsuranceVault(payable(params.contracts.dataStore.getAddress(Keys.INSURANCE_FUND_ADDRESS)));
+            if (address(insuranceVault) != address(0)) {
+                InsuranceFundUtils.deposit(
+                    params.contracts.dataStore,
+                    params.contracts.eventEmitter,
+                    insuranceVault,
+                    params.market.marketToken,
+                    collateralToken,
+                    params.orderKey,
+                    fees.insuranceFeeAmount
+                );
+            }
         }
     }
 }

--- a/contracts/reader/Reader.sol
+++ b/contracts/reader/Reader.sol
@@ -15,6 +15,8 @@ import "../position/PositionStoreUtils.sol";
 import "../market/MarketUtils.sol";
 import "../market/Market.sol";
 
+import "../insurance/InsuranceFundUtils.sol";
+
 import "./ReaderUtils.sol";
 import "./ReaderDepositUtils.sol";
 import "./ReaderWithdrawalUtils.sol";
@@ -353,5 +355,36 @@ contract Reader {
                 uiFeeReceiver,
                 swapPricingType
             );
+    }
+
+    // @dev Per-(market, token) insurance reserve bookkeeping. Distinct from
+    // the physical InsuranceVault ERC-20 balance: the bookkeeping value is
+    // the per-market share of vault holdings; vault.tokenBalances(token) is
+    // the sum of all market buckets for that token.
+    function getInsuranceFundBalance(
+        DataStore dataStore,
+        address market,
+        address token
+    ) external view returns (uint256) {
+        return InsuranceFundUtils.getBalance(dataStore, market, token);
+    }
+
+    // @dev Composite view of a market's insurance fund epoch state.
+    function getInsuranceFundEpochState(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external view returns (
+        uint256 epochPoolValue,
+        uint256 currentPoolValue,
+        uint256 drawdownFraction,
+        uint256 epochStart
+    ) {
+        (drawdownFraction, currentPoolValue, epochPoolValue) = InsuranceFundUtils.getDrawdownFraction(
+            dataStore,
+            market,
+            prices
+        );
+        epochStart = dataStore.getUint(Keys.insuranceFundEpochStartKey(market.marketToken));
     }
 }

--- a/contracts/test/InsuranceFundUtilsTest.sol
+++ b/contracts/test/InsuranceFundUtilsTest.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../insurance/InsuranceFundUtils.sol";
+import "../insurance/InsuranceVault.sol";
+import "../market/Market.sol";
+import "../market/MarketUtils.sol";
+
+// @title InsuranceFundUtilsTest
+// @dev External test wrapper around the internal InsuranceFundUtils library
+// so unit tests can call its functions through the normal hardhat-ethers path.
+// Mirrors the MarketUtilsTest pattern.
+//
+// The deployed instance must be granted CONTROLLER role on RoleStore at test
+// setup so it can drive MarketToken.transferOut, vault.transferOut /
+// recordTransferIn, DataStore writes, and EventEmitter calls.
+contract InsuranceFundUtilsTest {
+    function getBalance(DataStore dataStore, address market, address token) external view returns (uint256) {
+        return InsuranceFundUtils.getBalance(dataStore, market, token);
+    }
+
+    function getDrawdownFraction(
+        DataStore dataStore,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external view returns (uint256, uint256, uint256) {
+        return InsuranceFundUtils.getDrawdownFraction(dataStore, market, prices);
+    }
+
+    function deposit(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        bytes32 orderKey,
+        uint256 amount
+    ) external returns (uint256) {
+        return InsuranceFundUtils.deposit(dataStore, eventEmitter, vault, market, token, orderKey, amount);
+    }
+
+    function topUp(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        address market,
+        address token,
+        address depositor,
+        uint256 amount
+    ) external returns (uint256) {
+        return InsuranceFundUtils.topUp(dataStore, eventEmitter, vault, market, token, depositor, amount);
+    }
+
+    function attemptInjectPool(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        InsuranceVault vault,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices,
+        address pnlToken,
+        bytes32 orderKey
+    ) external returns (uint256) {
+        return InsuranceFundUtils.attemptInjectPool(dataStore, eventEmitter, vault, market, prices, pnlToken, orderKey);
+    }
+
+    function snapshotEpoch(
+        DataStore dataStore,
+        EventEmitter eventEmitter,
+        Market.Props memory market,
+        MarketUtils.MarketPrices memory prices
+    ) external returns (uint256) {
+        return InsuranceFundUtils.snapshotEpoch(dataStore, eventEmitter, market, prices);
+    }
+}

--- a/deploy/configureInsuranceFund.ts
+++ b/deploy/configureInsuranceFund.ts
@@ -1,0 +1,18 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import * as keys from "../utils/keys";
+import { setAddressIfDifferent } from "../utils/dataStore";
+
+// Wires the deployed InsuranceVault into the DataStore under Keys.INSURANCE_FUND_ADDRESS
+// (the slot that fee-addresses introduced for routing liquidation-fee insurance shares).
+// DecreasePositionCollateralUtils._distributeLiquidationShares reads this slot and
+// hands the slice to InsuranceFundUtils.deposit, which transfers the tokens out
+// of MarketToken into the vault. Library call sites resolve at runtime — see
+// design discussion in PR #31 thread.
+const func = async ({ deployments }: HardhatRuntimeEnvironment) => {
+  const insuranceVault = await deployments.get("InsuranceVault");
+  await setAddressIfDifferent(keys.INSURANCE_FUND_ADDRESS, insuranceVault.address, "insurance vault");
+};
+
+func.tags = ["InsuranceFundConfig"];
+func.dependencies = ["InsuranceVault", "DataStore", "Roles"];
+export default func;

--- a/deploy/deployDecreasePositionCollateralUtils.ts
+++ b/deploy/deployDecreasePositionCollateralUtils.ts
@@ -13,6 +13,7 @@ const func = createDeployFunction({
     "PositionEventUtils",
     "OrderEventUtils",
     "DecreasePositionSwapUtils",
+    "InsuranceFundUtils",
   ],
 });
 

--- a/deploy/deployInsuranceFundEventUtils.ts
+++ b/deploy/deployInsuranceFundEventUtils.ts
@@ -1,0 +1,7 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const func = createDeployFunction({
+  contractName: "InsuranceFundEventUtils",
+});
+
+export default func;

--- a/deploy/deployInsuranceFundUtils.ts
+++ b/deploy/deployInsuranceFundUtils.ts
@@ -1,0 +1,13 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const func = createDeployFunction({
+  contractName: "InsuranceFundUtils",
+  // InsuranceFundUtils.deposit / attemptInjectPool are external, so the library
+  // ships as its own deployment and is delegate-called from the contracts that
+  // link against it. InsuranceFundEventUtils is also external and gets linked
+  // here too — its events are emitted from inside deposit / attemptInjectPool /
+  // snapshotEpoch / topUp.
+  libraryNames: ["InsuranceFundEventUtils", "MarketEventUtils"],
+});
+
+export default func;

--- a/deploy/deployInsuranceVault.ts
+++ b/deploy/deployInsuranceVault.ts
@@ -1,0 +1,14 @@
+import { createDeployFunction } from "../utils/deploy";
+
+const constructorContracts = ["RoleStore", "DataStore"];
+
+const func = createDeployFunction({
+  contractName: "InsuranceVault",
+  dependencyNames: constructorContracts,
+  getDeployArgs: async ({ dependencyContracts }) => {
+    return constructorContracts.map((dependencyName) => dependencyContracts[dependencyName].address);
+  },
+  id: "InsuranceVault_1",
+});
+
+export default func;

--- a/deploy/deployReader.ts
+++ b/deploy/deployReader.ts
@@ -15,6 +15,7 @@ const func = createDeployFunction({
     "ReaderWithdrawalUtils",
     "ShiftStoreUtils",
     "WithdrawalStoreUtils",
+    "InsuranceFundUtils",
   ],
 });
 

--- a/deploy/deploySettlementHandler.ts
+++ b/deploy/deploySettlementHandler.ts
@@ -1,0 +1,20 @@
+import { grantRoleIfNotGranted } from "../utils/role";
+import { createDeployFunction } from "../utils/deploy";
+
+const constructorContracts = ["RoleStore", "DataStore", "EventEmitter", "Oracle"];
+
+const func = createDeployFunction({
+  contractName: "SettlementHandler",
+  dependencyNames: constructorContracts,
+  getDeployArgs: async ({ dependencyContracts }) => {
+    return constructorContracts.map((dependencyName) => dependencyContracts[dependencyName].address);
+  },
+  libraryNames: ["MarketStoreUtils", "InsuranceFundUtils"],
+  afterDeploy: async ({ deployedContract }) => {
+    // CONTROLLER lets the handler call dataStore writes, vault writes, and
+    // EventEmitter emits via the InsuranceFundUtils library.
+    await grantRoleIfNotGranted(deployedContract.address, "CONTROLLER");
+  },
+});
+
+export default func;

--- a/test/config/Config.ts
+++ b/test/config/Config.ts
@@ -447,6 +447,40 @@ describe("Config", () => {
     await config.setUint(keys.DATA_STREAM_SPREAD_REDUCTION_FACTOR, encodeData(["address"], [wnt.address]), p100);
   });
 
+  it("validates LIQUIDATION_FEE_VALIDATOR + INSURANCE sum ≤ 100%", async () => {
+    // Both factors are global. Set validator to 40%; insurance up to 60% must
+    // be accepted, 61% must revert. Without this invariant, the pool's residual
+    // in PositionPricingUtils.getPositionFees would underflow.
+    await config.connect(user0).setUint(keys.LIQUIDATION_FEE_VALIDATOR_FACTOR, "0x", percentageToFloat("40%"));
+    await config.connect(user0).setUint(keys.LIQUIDATION_FEE_INSURANCE_FACTOR, "0x", percentageToFloat("60%"));
+
+    await expect(
+      config.connect(user0).setUint(keys.LIQUIDATION_FEE_INSURANCE_FACTOR, "0x", percentageToFloat("60%").add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+
+    await expect(
+      config.connect(user0).setUint(keys.LIQUIDATION_FEE_VALIDATOR_FACTOR, "0x", percentageToFloat("40%").add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+  });
+
+  it("validates INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR off-sentinel + ≤ 100%", async () => {
+    const market = encodeData(["address"], [ethUsdMarket.marketToken]);
+    const p100 = percentageToFloat("100%");
+    const maxUint = ethers.constants.MaxUint256;
+
+    // off-sentinel must be settable
+    await config.connect(user0).setUint(keys.INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR, market, maxUint);
+    expect(await dataStore.getUint(keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken))).eq(maxUint);
+
+    // normal fraction must be settable
+    await config.connect(user0).setUint(keys.INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR, market, percentageToFloat("2%"));
+
+    // anything above 100% that isn't the sentinel must revert
+    await expect(
+      config.connect(user0).setUint(keys.INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR, market, p100.add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+  });
+
   it("setDataStream", async () => {
     const p100 = percentageToFloat("100%");
     const feedId = hashString("WNT");

--- a/test/insurance/InsuranceFundUtils.ts
+++ b/test/insurance/InsuranceFundUtils.ts
@@ -1,0 +1,289 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+import { deployContract } from "../../utils/deploy";
+import { deployFixture } from "../../utils/fixture";
+import { handleDeposit } from "../../utils/deposit";
+import { grantRole } from "../../utils/role";
+import { prices } from "../../utils/prices";
+import { expandDecimals, decimalToFloat, percentageToFloat } from "../../utils/math";
+import { parseLogs, getEventData } from "../../utils/event";
+import * as keys from "../../utils/keys";
+
+const MaxUint256 = hre.ethers.constants.MaxUint256;
+
+describe("InsuranceFundUtils", () => {
+  let fixture;
+  let wallet, user0;
+  let dataStore, eventEmitter, roleStore, insuranceVault, insuranceFundEventUtils, insuranceFundUtils;
+  let ethUsdMarket, wnt, usdc;
+  let testWrapper;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ wallet, user0 } = fixture.accounts);
+    ({
+      dataStore,
+      eventEmitter,
+      roleStore,
+      insuranceVault,
+      insuranceFundEventUtils,
+      insuranceFundUtils,
+      ethUsdMarket,
+      wnt,
+      usdc,
+    } = fixture.contracts);
+
+    // InsuranceFundUtils.deposit / attemptInjectPool are external — delegate-
+    // called via the deployed library address. Internal helpers (getBalance,
+    // snapshotEpoch, topUp, getDrawdownFraction) are inlined into the wrapper;
+    // those reach external InsuranceFundEventUtils for their event emits, so
+    // it must be linked too. (MarketEventUtils is no longer needed: the
+    // applyDeltaToPoolAmount path now lives behind the InsuranceFundUtils
+    // deployment.)
+    testWrapper = await deployContract("InsuranceFundUtilsTest", [], {
+      libraries: {
+        InsuranceFundUtils: insuranceFundUtils.address,
+        InsuranceFundEventUtils: insuranceFundEventUtils.address,
+      },
+    });
+
+    // CONTROLLER is checked in three places we hit through the wrapper:
+    //   - DataStore writes (applyDeltaToUint, setUint, incrementUint)
+    //   - MarketToken.transferOut (deposit path)
+    //   - InsuranceVault.transferOut / recordTransferIn / syncTokenBalance
+    //   - EventEmitter.emitEventLog*
+    // One CONTROLLER grant on the wrapper covers all of them.
+    await grantRole(roleStore, testWrapper.address, "CONTROLLER");
+
+    // Seed the LP pool so getPoolValueExcludingUnrealizedPnl returns non-zero.
+    // 1000 WETH @ $5000 = $5M long side; 1M USDC = $1M short side; pool = $6M.
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(1_000_000, 6),
+      },
+    });
+  });
+
+  it("getBalance returns 0 by default", async () => {
+    expect(await testWrapper.getBalance(dataStore.address, ethUsdMarket.marketToken, wnt.address)).eq(0);
+    expect(await testWrapper.getBalance(dataStore.address, ethUsdMarket.marketToken, usdc.address)).eq(0);
+  });
+
+  it("snapshotEpoch writes pool USD + timestamp and emits EpochReset", async () => {
+    const tx = await testWrapper.snapshotEpoch(
+      dataStore.address,
+      eventEmitter.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+    const receipt = await tx.wait();
+    const block = await hre.ethers.provider.getBlock(receipt.blockNumber);
+
+    const epochValue = await dataStore.getUint(keys.insuranceFundEpochPoolValueKey(ethUsdMarket.marketToken));
+    const epochStart = await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken));
+
+    // ~$6M scaled by 1e30, give or take borrowing accrual / impact pool which
+    // are zero in a fresh fixture.
+    expect(epochValue).gt(decimalToFloat(5_999_999));
+    expect(epochValue).lt(decimalToFloat(6_000_001));
+    expect(epochStart).eq(block.timestamp);
+
+    // Confirm event was emitted via EventEmitter (use the project's parseLogs helper)
+    const parsed = parseLogs(fixture, receipt);
+    const epochEvent = getEventData(parsed, "InsuranceFundEpochReset");
+    expect(epochEvent, "InsuranceFundEpochReset event missing").to.exist;
+    expect(epochEvent.market.toLowerCase()).eq(ethUsdMarket.marketToken.toLowerCase());
+    expect(epochEvent.epochPoolValue).eq(epochValue);
+    expect(epochEvent.timestamp).eq(epochStart);
+  });
+
+  it("getDrawdownFraction returns 0 when fund is disabled (no snapshot)", async () => {
+    const [drawdown, current, snap] = await testWrapper.getDrawdownFraction(
+      dataStore.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+    expect(drawdown).eq(0);
+    expect(snap).eq(0);
+    // current pool value should still be reported even when fund disabled
+    expect(current).gt(0);
+  });
+
+  it("getDrawdownFraction reflects realized pool drop after snapshot", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Simulate ~$500k realized PnL outflow by removing 100 WETH from the pool
+    // (100 * 5000 = 500k). At a snapshot of ~$6M, drawdown ~= 500k / 6M ~= 8.33%.
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    const [drawdown, current, snap] = await testWrapper.getDrawdownFraction(
+      dataStore.address,
+      ethUsdMarket,
+      prices.ethUsdMarket
+    );
+
+    expect(snap).gt(decimalToFloat(5_999_999));
+    expect(current).lt(snap);
+
+    // 500k / 6M ≈ 8.33% — allow a small band for borrowing/impact terms.
+    expect(drawdown).gt(percentageToFloat("8%"));
+    expect(drawdown).lt(percentageToFloat("9%"));
+  });
+
+  it("getDrawdownFraction returns 0 when epoch is stale", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Pool drop as before
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    // Enable stale check at 1 day, then advance time past it
+    await dataStore.setUint(keys.INSURANCE_FUND_MAX_EPOCH_AGE, 24 * 60 * 60);
+    await hre.network.provider.send("evm_increaseTime", [25 * 60 * 60]);
+    await hre.network.provider.send("evm_mine");
+
+    const [drawdown] = await testWrapper.getDrawdownFraction(dataStore.address, ethUsdMarket, prices.ethUsdMarket);
+    expect(drawdown).eq(0);
+  });
+
+  it("attemptInjectPool no-ops when triggerFactor is uint256.max", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+    // Default for an unset key is 0, but the "off" sentinel is uint256.max.
+    // setUint accepts the max value.
+    await dataStore.setUint(keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken), MaxUint256);
+
+    expect(
+      await testWrapper.callStatic.attemptInjectPool(
+        dataStore.address,
+        eventEmitter.address,
+        insuranceVault.address,
+        ethUsdMarket,
+        prices.ethUsdMarket,
+        wnt.address,
+        hre.ethers.constants.HashZero
+      )
+    ).eq(0);
+  });
+
+  it("attemptInjectPool no-ops when drawdown is at/below trigger", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // 8.33% drawdown vs 10% trigger ⇒ no inject
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("10%")
+    );
+
+    expect(
+      await testWrapper.callStatic.attemptInjectPool(
+        dataStore.address,
+        eventEmitter.address,
+        insuranceVault.address,
+        ethUsdMarket,
+        prices.ethUsdMarket,
+        wnt.address,
+        hre.ethers.constants.HashZero
+      )
+    ).eq(0);
+  });
+
+  it("attemptInjectPool emits Shortfall when reserve bucket is empty", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+
+    // Drop pool, set 2% trigger (drawdown ~= 8% > 2%)
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("2%")
+    );
+
+    const tx = await testWrapper.attemptInjectPool(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket,
+      prices.ethUsdMarket,
+      wnt.address,
+      hre.ethers.constants.HashZero
+    );
+    const receipt = await tx.wait();
+    const parsed = parseLogs(fixture, receipt);
+    const shortfall = getEventData(parsed, "InsuranceFundShortfall");
+    expect(shortfall, "InsuranceFundShortfall event missing").to.exist;
+    expect(shortfall.paid).eq(0);
+    expect(shortfall.requested).gt(0);
+
+    // No injection occurred — reserve and pool unchanged
+    expect(await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address))).eq(0);
+  });
+
+  it("attemptInjectPool injects to threshold when reserve is sufficient", async () => {
+    await testWrapper.snapshotEpoch(dataStore.address, eventEmitter.address, ethUsdMarket, prices.ethUsdMarket);
+    await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+    await dataStore.setUint(
+      keys.insuranceFundDrawdownTriggerFactorKey(ethUsdMarket.marketToken),
+      percentageToFloat("2%")
+    );
+
+    // Pre-fund the vault with 200 WETH and tag the reserve bucket.
+    // Drawdown is ~$500k; covering down to 2% requires ~ (500k - 2%*6M) / 5000
+    // = (500k - 120k)/5000 = 76 WETH. 200 WETH is plenty.
+    const reserveAmount = expandDecimals(200, 18);
+    // Mint fresh WETH from the wallet's hardhat-default ETH balance — the
+    // fixture only deposits 50 WETH which is below our reserve target.
+    await wnt.connect(wallet).deposit({ value: reserveAmount });
+    await wnt.connect(wallet).transfer(insuranceVault.address, reserveAmount);
+    await insuranceVault.syncTokenBalance(wnt.address);
+    await dataStore.setUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address), reserveAmount);
+
+    const poolAmountBefore = await dataStore.getUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address));
+    const tx = await testWrapper.attemptInjectPool(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket,
+      prices.ethUsdMarket,
+      wnt.address,
+      hre.ethers.constants.HashZero
+    );
+    await tx.wait();
+
+    const poolAmountAfter = await dataStore.getUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address));
+    const reserveAfter = await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address));
+
+    // Pool should have grown; reserve should have shrunk by the same WETH amount.
+    expect(poolAmountAfter).gt(poolAmountBefore);
+    const injected = poolAmountAfter.sub(poolAmountBefore);
+    expect(reserveAfter).eq(reserveAmount.sub(injected));
+
+    // Post-injection drawdown should sit at or below the trigger.
+    const [drawdownAfter] = await testWrapper.getDrawdownFraction(dataStore.address, ethUsdMarket, prices.ethUsdMarket);
+    expect(drawdownAfter).lte(percentageToFloat("2%"));
+  });
+
+  it("deposit moves tokens from MarketToken to vault and increments reserve", async () => {
+    const amount = expandDecimals(5, 6); // 5 USDC
+
+    // The MarketToken side of the deposit needs USDC to move out of. The
+    // handleDeposit in beforeEach left 1M USDC sitting in ethUsdMarket.
+    const vaultUsdcBefore = await usdc.balanceOf(insuranceVault.address);
+
+    await testWrapper.deposit(
+      dataStore.address,
+      eventEmitter.address,
+      insuranceVault.address,
+      ethUsdMarket.marketToken,
+      usdc.address,
+      hre.ethers.constants.HashZero,
+      amount
+    );
+
+    expect(await usdc.balanceOf(insuranceVault.address)).eq(vaultUsdcBefore.add(amount));
+    expect(await dataStore.getUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, usdc.address))).eq(amount);
+  });
+});

--- a/test/insurance/Reader.ts
+++ b/test/insurance/Reader.ts
@@ -1,0 +1,75 @@
+import { expect } from "chai";
+
+import { deployFixture } from "../../utils/fixture";
+import { handleDeposit } from "../../utils/deposit";
+import { prices } from "../../utils/prices";
+import { expandDecimals, decimalToFloat, percentageToFloat } from "../../utils/math";
+import * as keys from "../../utils/keys";
+
+describe("Reader insurance fund getters", () => {
+  let fixture;
+  let dataStore, reader, ethUsdMarket, wnt;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ dataStore, reader, ethUsdMarket, wnt } = fixture.contracts);
+
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(1_000_000, 6),
+      },
+    });
+  });
+
+  describe("getInsuranceFundBalance", () => {
+    it("returns 0 by default", async () => {
+      expect(await reader.getInsuranceFundBalance(dataStore.address, ethUsdMarket.marketToken, wnt.address)).eq(0);
+    });
+
+    it("returns the bookkept value", async () => {
+      const amount = expandDecimals(7, 18);
+      await dataStore.setUint(keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address), amount);
+      expect(await reader.getInsuranceFundBalance(dataStore.address, ethUsdMarket.marketToken, wnt.address)).eq(amount);
+    });
+  });
+
+  describe("getInsuranceFundEpochState", () => {
+    it("returns zeros when fund is uninitialized", async () => {
+      const [epochValue, currentValue, drawdown, epochStart] = await reader.getInsuranceFundEpochState(
+        dataStore.address,
+        ethUsdMarket,
+        prices.ethUsdMarket
+      );
+      expect(epochValue).eq(0);
+      // currentValue is still computed even when fund is disabled — it's the
+      // live pool USD that operators want to see on a dashboard.
+      expect(currentValue).gt(0);
+      expect(drawdown).eq(0);
+      expect(epochStart).eq(0);
+    });
+
+    it("reports drawdown after snapshot + pool drop", async () => {
+      // Simulate a snapshot directly. The SettlementHandler tests cover the
+      // real entrypoint; here we focus on the Reader composition.
+      await dataStore.setUint(keys.insuranceFundEpochPoolValueKey(ethUsdMarket.marketToken), decimalToFloat(6_000_000));
+      const epochStartTs = Math.floor(Date.now() / 1000);
+      await dataStore.setUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken), epochStartTs);
+
+      // Drop 100 WETH = ~$500k = ~8.33% drawdown vs $6M snapshot.
+      await dataStore.decrementUint(keys.poolAmountKey(ethUsdMarket.marketToken, wnt.address), expandDecimals(100, 18));
+
+      const [epochValue, currentValue, drawdown, epochStart] = await reader.getInsuranceFundEpochState(
+        dataStore.address,
+        ethUsdMarket,
+        prices.ethUsdMarket
+      );
+      expect(epochValue).eq(decimalToFloat(6_000_000));
+      expect(currentValue).lt(epochValue);
+      expect(drawdown).gt(percentageToFloat("8%"));
+      expect(drawdown).lt(percentageToFloat("9%"));
+      expect(epochStart).eq(epochStartTs);
+    });
+  });
+});

--- a/test/insurance/SettlementHandler.ts
+++ b/test/insurance/SettlementHandler.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+import { deployFixture } from "../../utils/fixture";
+import { handleDeposit } from "../../utils/deposit";
+import { grantRole } from "../../utils/role";
+import { parseLogs, getEventData } from "../../utils/event";
+import { expandDecimals, decimalToFloat } from "../../utils/math";
+import { errorsContract } from "../../utils/error";
+import * as keys from "../../utils/keys";
+
+describe("SettlementHandler", () => {
+  let fixture;
+  let wallet, user0;
+  let dataStore, roleStore, settlementHandler, ethUsdMarket, wnt, usdc;
+  let chainlinkPriceFeedProvider;
+  let oracleParams;
+
+  beforeEach(async () => {
+    fixture = await deployFixture();
+    ({ wallet, user0 } = fixture.accounts);
+    ({ dataStore, roleStore, settlementHandler, ethUsdMarket, wnt, usdc, chainlinkPriceFeedProvider } =
+      fixture.contracts);
+
+    // Seed the LP pool so getPoolValueExcludingUnrealizedPnl returns non-zero.
+    await handleDeposit(fixture, {
+      create: {
+        market: ethUsdMarket,
+        longTokenAmount: expandDecimals(1000, 18),
+        shortTokenAmount: expandDecimals(1_000_000, 6),
+      },
+    });
+
+    // Use the chainlink price feed provider for the snapshot's withOraclePrices
+    // modifier. The price feeds are already set in the fixture (~$5000 WETH, $1 USDC).
+    await dataStore.setAddress(keys.oracleProviderForTokenKey(wnt.address), chainlinkPriceFeedProvider.address);
+    await dataStore.setAddress(keys.oracleProviderForTokenKey(usdc.address), chainlinkPriceFeedProvider.address);
+    oracleParams = {
+      tokens: [wnt.address, usdc.address],
+      providers: [chainlinkPriceFeedProvider.address, chainlinkPriceFeedProvider.address],
+      data: ["0x", "0x"],
+    };
+
+    // ORDER_KEEPER is the snapshotEpoch permission. Grant the deployer wallet
+    // for happy-path tests; user0 stays unauthorized to test the rejection.
+    await grantRole(roleStore, wallet.address, "ORDER_KEEPER");
+  });
+
+  it("snapshots epoch state and emits EpochReset on first call", async () => {
+    expect(await dataStore.getUint(keys.insuranceFundEpochPoolValueKey(ethUsdMarket.marketToken))).eq(0);
+    expect(await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken))).eq(0);
+
+    const tx = await settlementHandler.connect(wallet).snapshotEpoch(ethUsdMarket.marketToken, oracleParams);
+    const receipt = await tx.wait();
+    const block = await hre.ethers.provider.getBlock(receipt.blockNumber);
+
+    const epochValue = await dataStore.getUint(keys.insuranceFundEpochPoolValueKey(ethUsdMarket.marketToken));
+    const epochStart = await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken));
+
+    expect(epochValue).gt(decimalToFloat(5_999_999));
+    expect(epochValue).lt(decimalToFloat(6_000_001));
+    expect(epochStart).eq(block.timestamp);
+
+    const parsed = parseLogs(fixture, receipt);
+    const ev = getEventData(parsed, "InsuranceFundEpochReset");
+    expect(ev, "InsuranceFundEpochReset event").to.exist;
+    expect(ev.market.toLowerCase()).eq(ethUsdMarket.marketToken.toLowerCase());
+    expect(ev.epochPoolValue).eq(epochValue);
+  });
+
+  it("reverts when called again within INSURANCE_FUND_EPOCH_LENGTH", async () => {
+    // 7 days
+    await dataStore.setUint(keys.INSURANCE_FUND_EPOCH_LENGTH, 7 * 24 * 60 * 60);
+
+    await settlementHandler.connect(wallet).snapshotEpoch(ethUsdMarket.marketToken, oracleParams);
+
+    // Immediate re-call (no time advance) must revert with the typed error.
+    await expect(
+      settlementHandler.connect(wallet).snapshotEpoch(ethUsdMarket.marketToken, oracleParams)
+    ).to.be.revertedWithCustomError(errorsContract, "InsuranceFundEpochNotYetElapsed");
+  });
+
+  it("allows re-snapshot after INSURANCE_FUND_EPOCH_LENGTH elapses", async () => {
+    await dataStore.setUint(keys.INSURANCE_FUND_EPOCH_LENGTH, 7 * 24 * 60 * 60);
+
+    await settlementHandler.connect(wallet).snapshotEpoch(ethUsdMarket.marketToken, oracleParams);
+    const firstStart = await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken));
+
+    // Advance just past one epoch length.
+    await hre.network.provider.send("evm_increaseTime", [7 * 24 * 60 * 60 + 1]);
+    await hre.network.provider.send("evm_mine");
+
+    await settlementHandler.connect(wallet).snapshotEpoch(ethUsdMarket.marketToken, oracleParams);
+    const secondStart = await dataStore.getUint(keys.insuranceFundEpochStartKey(ethUsdMarket.marketToken));
+
+    expect(secondStart).gt(firstStart);
+  });
+
+  it("reverts for callers without ORDER_KEEPER role", async () => {
+    await expect(
+      settlementHandler.connect(user0).snapshotEpoch(ethUsdMarket.marketToken, oracleParams)
+    ).to.be.revertedWithCustomError(errorsContract, "Unauthorized");
+  });
+});

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -32,6 +32,11 @@ export const EXCLUDED_CONFIG_KEYS = {
   BUYBACK_FEE_RECEIVER: true,
   VALIDATOR_FEE_RECEIVER: true,
   INSURANCE_FUND_ADDRESS: true,
+  // InsuranceFund runtime state (written by InsuranceFundUtils.deposit /
+  // attemptInjectPool / snapshotEpoch, never Config-tunable).
+  INSURANCE_FUND_BALANCE: true,
+  INSURANCE_FUND_EPOCH_POOL_VALUE: true,
+  INSURANCE_FUND_EPOCH_START: true,
   POSITION_FEE_VEALPHA_FACTOR: true,
   POSITION_FEE_TREASURY_FACTOR: true,
   POSITION_FEE_BUYBACK_FACTOR: true,

--- a/utils/fixture.ts
+++ b/utils/fixture.ts
@@ -72,6 +72,10 @@ export async function deployFixture() {
   const eventEmitter = await hre.ethers.getContract("EventEmitter");
   const oracleStore = await hre.ethers.getContract("OracleStore");
   const orderVault = await hre.ethers.getContract("OrderVault");
+  const insuranceVault = await hre.ethers.getContract("InsuranceVault");
+  const insuranceFundEventUtils = await hre.ethers.getContract("InsuranceFundEventUtils");
+  const insuranceFundUtils = await hre.ethers.getContract("InsuranceFundUtils");
+  const settlementHandler = await hre.ethers.getContract("SettlementHandler");
   const glvVault = await hre.ethers.getContract("GlvVault");
   const marketFactory = await hre.ethers.getContract("MarketFactory");
   const glvFactory = await hre.ethers.getContract("GlvFactory");
@@ -265,6 +269,10 @@ export async function deployFixture() {
       shiftVault,
       oracleStore,
       orderVault,
+      insuranceVault,
+      insuranceFundEventUtils,
+      insuranceFundUtils,
+      settlementHandler,
       marketFactory,
       depositHandler,
       depositUtils,

--- a/utils/keys.ts
+++ b/utils/keys.ts
@@ -161,6 +161,13 @@ export const BUYBACK_FEE_RECEIVER = hashString("BUYBACK_FEE_RECEIVER");
 export const VALIDATOR_FEE_RECEIVER = hashString("VALIDATOR_FEE_RECEIVER");
 export const INSURANCE_FUND_ADDRESS = hashString("INSURANCE_FUND_ADDRESS");
 
+export const INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR = hashString("INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR");
+export const INSURANCE_FUND_BALANCE = hashString("INSURANCE_FUND_BALANCE");
+export const INSURANCE_FUND_EPOCH_POOL_VALUE = hashString("INSURANCE_FUND_EPOCH_POOL_VALUE");
+export const INSURANCE_FUND_EPOCH_START = hashString("INSURANCE_FUND_EPOCH_START");
+export const INSURANCE_FUND_MAX_EPOCH_AGE = hashString("INSURANCE_FUND_MAX_EPOCH_AGE");
+export const INSURANCE_FUND_EPOCH_LENGTH = hashString("INSURANCE_FUND_EPOCH_LENGTH");
+
 export const SWAP_FEE_FACTOR = hashString("SWAP_FEE_FACTOR");
 export const DEPOSIT_FEE_FACTOR = hashString("DEPOSIT_FEE_FACTOR");
 export const WITHDRAWAL_FEE_FACTOR = hashString("WITHDRAWAL_FEE_FACTOR");
@@ -620,6 +627,22 @@ export function proDiscountFactorKey(proTier: number) {
 
 export function liquidationFeeFactorKey(market: string) {
   return hashData(["bytes32", "address"], [LIQUIDATION_FEE_FACTOR, market]);
+}
+
+export function insuranceFundDrawdownTriggerFactorKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR, market]);
+}
+
+export function insuranceFundBalanceKey(market: string, token: string) {
+  return hashData(["bytes32", "address", "address"], [INSURANCE_FUND_BALANCE, market, token]);
+}
+
+export function insuranceFundEpochPoolValueKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_EPOCH_POOL_VALUE, market]);
+}
+
+export function insuranceFundEpochStartKey(market: string) {
+  return hashData(["bytes32", "address"], [INSURANCE_FUND_EPOCH_START, market]);
 }
 
 export function latestAdlBlockKey(market: string, isLong: boolean) {


### PR DESCRIPTION
## Motivation

LPs absorb 100% of the pool's USD drawdown between weekly settlement windows today. There's no mechanism to absorb mid-epoch realized losses from trader PnL — an LP withdrawing on a Friday eats whatever the pool lost since the prior Friday.

This PR introduces a **per-market insurance fund**: a configurable share of every liquidation fee and every regular position fee is routed into a segregated reserve. When realized pool drawdown (current pool USD vs. the last epoch's snapshot, both excluding unrealized trader PnL) crosses a per-market threshold, the fund injects capital back into the pool inside the same transaction. LP NAV between Fridays is bounded below by `epochPoolValue × (1 − triggerFactor)`, modulo unrealized mark moves.

## How it works

**Collection (every position close)**

`PositionPricingUtils` carves two slices out of the protocol fee:

- `liquidationFeeAmountForInsurance` — share of the liquidation fee (per-market `INSURANCE_FUND_FEE_FACTOR`)
- `positionFeeAmountForInsurance` — share of the regular position fee (per-market `INSURANCE_FUND_POSITION_FEE_FACTOR`)

`DecreasePositionCollateralUtils.processCollateral` transfers the combined slice from `MarketToken` into a singleton `InsuranceVault` (a `StrictBank` extension) and increments per-(market, token) bookkeeping in `DataStore`. The pool's residual share (`feeAmountForPool`) is reduced by exactly the same amount — no double counting.

Why both slices: liquidation-only collection is starved by insolvent liquidations (the early-return path in `processCollateral` zeroes the liquidation fee struct exactly when LPs are most exposed). The regular position-fee slice keeps the fund accruing in calm markets too.

**Injection (every position close, end-of-`processCollateral`)**

`InsuranceFundUtils.attemptInjectPool` runs at the end of every close, ADL, and liquidation:

1. Read `INSURANCE_FUND_DRAWDOWN_TRIGGER_FACTOR` — short-circuits if set to the off-sentinel (`type(uint256).max`).
2. Compute current drawdown via `MarketUtils.getPoolValueExcludingUnrealizedPnl` against the epoch snapshot. Short-circuits if drawdown ≤ trigger, or if the snapshot is uninitialized / stale (older than `INSURANCE_FUND_MAX_EPOCH_AGE`).
3. Compute the token amount needed to bring drawdown back to the threshold (`(targetCurrentValue − currentValue) / pnlTokenPrice.min`, LP-favorable rounding).
4. Clamp to the per-(market, pnlToken) reserve bucket. If insufficient, emit `InsuranceFundShortfall` and partially inject.
5. `vault.transferOut(pnlToken, marketToken, injected)` + `applyDeltaToPoolAmount(+injected)` + decrement the bucket + emit `InsuranceFundInjection`.

The trader's payout path is completely untouched — the close still debits the pool, transfers via `MarketToken.transferOut`, and the injection runs after the debit but inside the same tx.

**Epoch lifecycle (weekly keeper call)**

`SettlementHandler.snapshotEpoch(market, oracleParams)` is the keeper entrypoint:

- `onlyOrderKeeper`, `globalNonReentrant`, `withOraclePrices`
- Idempotency guard: reverts with `InsuranceFundEpochNotYetElapsed` if `block.timestamp < lastEpochStart + INSURANCE_FUND_EPOCH_LENGTH`
- Calls `InsuranceFundUtils.snapshotEpoch` to write the new baseline + timestamp + emit `InsuranceFundEpochReset`

## Architecture

| Layer | Contract / Library | Purpose |
|---|---|---|
| Storage keys | `contracts/data/Keys.sol` | 9 new constants + 6 per-market key helpers |
| Custody | `contracts/insurance/InsuranceVault.sol` | Singleton `StrictBank` extension |
| Bookkeeping invariant: `vault.tokenBalances(token) >= sum(reserve buckets for token)` |
| Logic | `contracts/insurance/InsuranceFundUtils.sol` | `deposit`, `topUp`, `getDrawdownFraction`, `attemptInjectPool`, `snapshotEpoch` |
| Events | `contracts/insurance/InsuranceFundEventUtils.sol` | `Deposit`, `Injection`, `Shortfall`, `EpochReset`, `ManualDeposit` — emitted via `EventEmitter` for indexer consumption |
| Pool valuation | `contracts/market/MarketUtils.sol` | New `getPoolValueExcludingUnrealizedPnl` aggregator composing `getPoolUsdWithoutPnl` + borrowing-fee + impact-pool terms (skips capped PnL) |
| Fee carving | `contracts/pricing/PositionPricingUtils.sol` | Extended `PositionLiquidationFees` + `PositionFees` structs with insurance fields; `getLiquidationFees` and `getPositionFeesAfterReferral` compute and subtract the slices |
| Collection + injection hooks | `contracts/position/DecreasePositionCollateralUtils.sol` | Transfer slice → vault in fee-success branch; `attemptInjectPool` at end-of-function |
| Keeper entrypoint | `contracts/insurance/SettlementHandler.sol` | Permissioned `snapshotEpoch(market, oracleParams)` with idempotency guard |
| Read surface | `contracts/reader/Reader.sol` | `getInsuranceFundBalance`, `getInsuranceFundEpochState` |
| Governance | `contracts/config/ConfigAllowedKeys.sol`, `contracts/config/ConfigValidatorUtils.sol` | Whitelist the 5 governable factors; sum-of-shares + conservative 50% cap on global liquidation receivers; off-sentinel-aware check on the drawdown trigger |
| Wiring | `deploy/configureInsuranceFund.ts` | Sets `Keys.INSURANCE_VAULT` to the deployed vault address (library call sites resolve at runtime, matching the `HOLDING_ADDRESS` pattern) |

## Design decisions worth flagging on review

1. **Vault address via `DataStore.getAddress(Keys.INSURANCE_VAULT)`**, not constructor injection. Libraries can't hold immutable state, so the injection-from-a-library design in spec §4.2 was switched to the `HOLDING_ADDRESS`-style pattern.

2. **`type(uint256).max` is the off-sentinel for the drawdown trigger**, not zero. Zero semantically means "inject on any drawdown." Operators must explicitly set max in Config to mark a market as not-yet-onboarded.

3. **Conservative 50% cap on `LIQUIDATION_FEE_RECEIVER_FACTOR + LIQUIDATION_FEE_SECONDARY_RECEIVER_FACTOR`** (the two factors are global; `INSURANCE_FUND_FEE_FACTOR` is per-market). Per-market check on the insurance key reads both globals and asserts the sum; per-global check applies a conservative cap that leaves 50% headroom for any per-market insurance share — avoids iterating every market in a `view` function. Lifting this cap is a follow-up if needed (see spec §4.1 implementer note).

4. **`internal` → `external` on `deposit` / `attemptInjectPool` / `snapshotEpoch`**, `public` on `getDrawdownFraction`. Inlining all of them into `DecreasePositionCollateralUtils` pushed it over the 24,576-byte contract size limit. Routing through DELEGATECALL keeps everything deployable; gas cost is acceptable since these are once-per-close operations.

5. **`processCollateral` injection hook at end-of-function**, not adjacent to any specific `applyDeltaToPoolAmount` branch. There are six `applyDeltaToPoolAmount` call sites in `processCollateral` (positive PnL, price impact, negative PnL × 2, fees × 2, negative price impact × 2). Single end-of-function hook sees the post-close pool state from all of them and is easier to audit.

## Events

All routed through the existing `EventEmitter`. Indexer surface is purely additive.

- `InsuranceFundDeposit(market, token, orderKey, amount, newBalance)`
- `InsuranceFundInjection(market, token, orderKey, amount, newPoolAmount, newReserveBalance, drawdownBefore, drawdownAfter)`
- `InsuranceFundShortfall(market, token, orderKey, requested, paid)` — when reserve can't cover full request
- `InsuranceFundEpochReset(market, epochPoolValue, timestamp)`
- `InsuranceFundManualDeposit(market, token, depositor, amount, newBalance)` — for governance top-up
- `PositionFeesInfo` (existing) — extended with insurance fields when `liquidation.liquidationFeeAmount > 0` or `positionFeeAmountForInsurance > 0`

```ts