### PR TITLE
fix(position): scale receivers proportionally instead of zeroing on insolvent close

### DIFF
--- a/contracts/config/ConfigValidatorUtils.sol
+++ b/contracts/config/ConfigValidatorUtils.sol
@@ -189,6 +189,34 @@ library ConfigValidatorUtils {
             }
         }
 
+        // Position fee receivers (veAlpha + treasury + buyback) have the
+        // same underflow surface as the liquidation pair above:
+        //   fees.positionFeeAmountForPool =
+        //       fees.protocolFeeAmount
+        //       - fees.veAlphaFeeAmount
+        //       - fees.treasuryFeeAmount
+        //       - fees.buybackFeeAmount;
+        // If the three factors sum to > 1e30 the uint256 subtraction underflows.
+        // Enforce the sum here on whichever of the three is being set.
+        if (
+            baseKey == Keys.POSITION_FEE_VEALPHA_FACTOR ||
+            baseKey == Keys.POSITION_FEE_TREASURY_FACTOR ||
+            baseKey == Keys.POSITION_FEE_BUYBACK_FACTOR
+        ) {
+            uint256 vealpha = baseKey == Keys.POSITION_FEE_VEALPHA_FACTOR
+                ? value
+                : dataStore.getUint(Keys.POSITION_FEE_VEALPHA_FACTOR);
+            uint256 treasury = baseKey == Keys.POSITION_FEE_TREASURY_FACTOR
+                ? value
+                : dataStore.getUint(Keys.POSITION_FEE_TREASURY_FACTOR);
+            uint256 buyback = baseKey == Keys.POSITION_FEE_BUYBACK_FACTOR
+                ? value
+                : dataStore.getUint(Keys.POSITION_FEE_BUYBACK_FACTOR);
+            if (vealpha + treasury + buyback > Precision.FLOAT_PRECISION) {
+                revert Errors.ConfigValueExceedsAllowedRange(baseKey, value);
+            }
+        }
+
         // Drawdown trigger factor: type(uint256).max is the off-sentinel
         // (operators set this to disable the fund on a market). Otherwise
         // value must be ≤ 100% so the threshold is a fraction of pool USD.

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -337,19 +337,8 @@ library DecreasePositionCollateralUtils {
                 fees.ui.uiFeeAmount,
                 Keys.UI_POSITION_FEE_TYPE
             );
-        } else {
-            // the fees are expected to be paid in the collateral token
-            // if there are insufficient funds to pay for fees entirely in the collateral token
-            // then credit the fee amount entirely to the pool
-            if (collateralCache.result.amountPaidInCollateralToken > 0) {
-                MarketUtils.applyDeltaToPoolAmount(
-                    params.contracts.dataStore,
-                    params.contracts.eventEmitter,
-                    params.market,
-                    params.position.collateralToken(),
-                    collateralCache.result.amountPaidInCollateralToken.toInt256()
-                );
-            }
+        } else if (collateralCache.result.remainingCostUsd > 0) {
+            _distributeInsolventShares(params, fees, collateralCache.result.amountPaidInCollateralToken);
 
             if (collateralCache.result.amountPaidInSecondaryOutputToken > 0) {
                 MarketUtils.applyDeltaToPoolAmount(
@@ -360,10 +349,25 @@ library DecreasePositionCollateralUtils {
                     collateralCache.result.amountPaidInSecondaryOutputToken.toInt256()
                 );
             }
-
-            // empty the fees since the amount was entirely paid to the pool instead of for fees
-            // it is possible for the txn execution to still complete even in this case
-            // as long as the remainingCostUsd is still zero
+        } else {
+            if (collateralCache.result.amountPaidInCollateralToken > 0) {
+                MarketUtils.applyDeltaToPoolAmount(
+                    params.contracts.dataStore,
+                    params.contracts.eventEmitter,
+                    params.market,
+                    params.position.collateralToken(),
+                    collateralCache.result.amountPaidInCollateralToken.toInt256()
+                );
+            }
+            if (collateralCache.result.amountPaidInSecondaryOutputToken > 0) {
+                MarketUtils.applyDeltaToPoolAmount(
+                    params.contracts.dataStore,
+                    params.contracts.eventEmitter,
+                    params.market,
+                    values.output.secondaryOutputToken,
+                    collateralCache.result.amountPaidInSecondaryOutputToken.toInt256()
+                );
+            }
             fees = getEmptyFees(fees);
         }
 
@@ -815,6 +819,66 @@ library DecreasePositionCollateralUtils {
                     fees.insuranceFeeAmount
                 );
             }
+        }
+    }
+
+    // @dev Insolvent / partial-payment fee distribution for the collateral-
+    // token portion of the recovered amount. Scales each receiver share by
+    //   scale = amountPaidInCollateralToken / totalCostAmountExcludingFunding
+    // (capped at 1.0) so the sum of distributed shares stays ≤ recovered.
+    //
+    // Mutates `fees` in place — handleEarlyReturn's PositionFeesInfo emit
+    // downstream will reflect the scaled values that were actually written.
+    function _distributeInsolventShares(
+        PositionUtils.UpdatePositionParams memory params,
+        PositionPricingUtils.PositionFees memory fees,
+        uint256 amountPaidInCollateralToken
+    ) internal {
+        if (amountPaidInCollateralToken == 0 || fees.totalCostAmountExcludingFunding == 0) {
+            // Nothing recovered or nothing owed — no scaled distribution.
+            // handleEarlyReturn will return getEmptyFees(fees) downstream.
+            return;
+        }
+
+        uint256 scale = Precision.toFactor(
+            amountPaidInCollateralToken,
+            fees.totalCostAmountExcludingFunding
+        );
+        if (scale > Precision.FLOAT_PRECISION) {
+            scale = Precision.FLOAT_PRECISION;
+        }
+
+        fees.feeAmountForPool = Precision.applyFactor(fees.feeAmountForPool, scale);
+        fees.veAlphaFeeAmount = Precision.applyFactor(fees.veAlphaFeeAmount, scale);
+        fees.treasuryFeeAmount = Precision.applyFactor(fees.treasuryFeeAmount, scale);
+        fees.buybackFeeAmount = Precision.applyFactor(fees.buybackFeeAmount, scale);
+        fees.validatorFeeAmount = Precision.applyFactor(fees.validatorFeeAmount, scale);
+        fees.insuranceFeeAmount = Precision.applyFactor(fees.insuranceFeeAmount, scale);
+        fees.ui.uiFeeAmount = Precision.applyFactor(fees.ui.uiFeeAmount, scale);
+
+        address collateralToken = params.position.collateralToken();
+
+        if (fees.feeAmountForPool > 0) {
+            MarketUtils.applyDeltaToPoolAmount(
+                params.contracts.dataStore,
+                params.contracts.eventEmitter,
+                params.market,
+                collateralToken,
+                fees.feeAmountForPool.toInt256()
+            );
+        }
+        _distributeTransactionShares(params, fees, collateralToken);
+        _distributeLiquidationShares(params, fees, collateralToken);
+        if (fees.ui.uiFeeAmount > 0) {
+            FeeUtils.incrementClaimableUiFeeAmount(
+                params.contracts.dataStore,
+                params.contracts.eventEmitter,
+                params.order.uiFeeReceiver(),
+                params.market.marketToken,
+                collateralToken,
+                fees.ui.uiFeeAmount,
+                Keys.UI_POSITION_FEE_TYPE
+            );
         }
     }
 }

--- a/contracts/position/DecreasePositionCollateralUtils.sol
+++ b/contracts/position/DecreasePositionCollateralUtils.sol
@@ -315,13 +315,19 @@ library DecreasePositionCollateralUtils {
             // this imbalance
             // the swap impact pool should be built up so that it can be used to pay for positive price impact
             // for re-balancing to help handle this case
-            MarketUtils.applyDeltaToPoolAmount(
-                params.contracts.dataStore,
-                params.contracts.eventEmitter,
-                params.market,
-                params.position.collateralToken(),
-                fees.feeAmountForPool.toInt256()
-            );
+            //
+            // Skip the pool delta when feeAmountForPool is zero — avoids an empty
+            // PoolAmountUpdated event and matches the guard in
+            // _distributeInsolventShares. (Cannot be negative; type is uint256.)
+            if (fees.feeAmountForPool > 0) {
+                MarketUtils.applyDeltaToPoolAmount(
+                    params.contracts.dataStore,
+                    params.contracts.eventEmitter,
+                    params.market,
+                    params.position.collateralToken(),
+                    fees.feeAmountForPool.toInt256()
+                );
+            }
 
             address collateralToken = params.position.collateralToken();
 

--- a/test/config/Config.ts
+++ b/test/config/Config.ts
@@ -481,6 +481,28 @@ describe("Config", () => {
     ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
   });
 
+  it("validates POSITION_FEE_VEALPHA + TREASURY + BUYBACK sum ≤ 100%", async () => {
+    // The three position-fee receiver factors share the same underflow risk
+    // as the liquidation pair: positionFeeAmountForPool = protocolFee - vealpha
+    // - treasury - buyback (uint256). If the sum exceeds 100% the subtraction
+    // underflows. Verify the validator rejects sums above 100% and accepts
+    // exactly 100%.
+    await config.connect(user0).setUint(keys.POSITION_FEE_VEALPHA_FACTOR, "0x", percentageToFloat("40%"));
+    await config.connect(user0).setUint(keys.POSITION_FEE_TREASURY_FACTOR, "0x", percentageToFloat("30%"));
+    await config.connect(user0).setUint(keys.POSITION_FEE_BUYBACK_FACTOR, "0x", percentageToFloat("30%"));
+
+    // Boundary 40+30+30 = 100% accepted; +1 wei on any leg reverts.
+    await expect(
+      config.connect(user0).setUint(keys.POSITION_FEE_VEALPHA_FACTOR, "0x", percentageToFloat("40%").add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+    await expect(
+      config.connect(user0).setUint(keys.POSITION_FEE_TREASURY_FACTOR, "0x", percentageToFloat("30%").add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+    await expect(
+      config.connect(user0).setUint(keys.POSITION_FEE_BUYBACK_FACTOR, "0x", percentageToFloat("30%").add(1))
+    ).to.be.revertedWithCustomError(errorsContract, "ConfigValueExceedsAllowedRange");
+  });
+
   it("setDataStream", async () => {
     const p100 = percentageToFloat("100%");
     const feedId = hashString("WNT");

--- a/test/exchange/LiquidationFeeSplit.ts
+++ b/test/exchange/LiquidationFeeSplit.ts
@@ -12,24 +12,21 @@ import * as keys from "../../utils/keys";
 describe("Exchange.LiquidationFeeSplit", () => {
   let fixture;
   let wallet, user0;
-  let roleStore, dataStore, ethUsdMarket, wnt, usdc;
-  let validatorReceiver, insuranceFundAddress;
+  let roleStore, dataStore, ethUsdMarket, wnt, usdc, insuranceVault;
+  let validatorReceiver;
 
   beforeEach(async () => {
     fixture = await deployFixture();
     ({ wallet, user0 } = fixture.accounts);
-    ({ roleStore, dataStore, ethUsdMarket, wnt, usdc } = fixture.contracts);
+    ({ roleStore, dataStore, ethUsdMarket, wnt, usdc, insuranceVault } = fixture.contracts);
 
     validatorReceiver = fixture.accounts.user1.address;
-    insuranceFundAddress = fixture.accounts.user2.address;
-
     await dataStore.setAddress(keys.VALIDATOR_FEE_RECEIVER, validatorReceiver);
-    await dataStore.setAddress(keys.INSURANCE_FUND_ADDRESS, insuranceFundAddress);
-
-    // 0.5% liquidation fee, with 30%/20% splits → pool keeps 50%
-    await dataStore.setUint(keys.liquidationFeeFactorKey(ethUsdMarket.marketToken), decimalToFloat(5, 3));
+    await dataStore.setUint(keys.liquidationFeeFactorKey(ethUsdMarket.marketToken), decimalToFloat(30, 2));
     await dataStore.setUint(keys.LIQUIDATION_FEE_VALIDATOR_FACTOR, decimalToFloat(30, 2));
     await dataStore.setUint(keys.LIQUIDATION_FEE_INSURANCE_FACTOR, decimalToFloat(20, 2));
+
+    await dataStore.setUint(keys.minMmrKey(ethUsdMarket.marketToken), decimalToFloat(20, 2));
 
     await handleDeposit(fixture, {
       create: {
@@ -39,10 +36,7 @@ describe("Exchange.LiquidationFeeSplit", () => {
     });
   });
 
-  // TODO: this scenario hits the insolvent-close path at $4000, which
-  // bypasses _distributeLiquidationShares. Restructure with a leverage-based
-  // liquidation that leaves remaining collateral.
-  it.skip("splits liquidation fees between validator, insurance fund, and pool", async () => {
+  it("splits liquidation fees between validator, insurance fund, and pool on an insolvent close", async () => {
     // Open 10 WETH collateral ($50k at $5k), $200k size — 4x leverage.
     await handleOrder(fixture, {
       create: {
@@ -67,34 +61,34 @@ describe("Exchange.LiquidationFeeSplit", () => {
       market: ethUsdMarket,
       collateralToken: wnt,
       isLong: true,
-      minPrices: [expandDecimals(4000, 4), expandDecimals(1, 6)],
-      maxPrices: [expandDecimals(4000, 4), expandDecimals(1, 6)],
+      // Price $4500 → PnL -$20k, $30k collateral remaining; fees $60k → 50%
+      // partial payment, exercising _distributeInsolventShares scaling.
+      minPrices: [expandDecimals(4500, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(4500, 4), expandDecimals(1, 6)],
       gasUsageLabel: "liquidationHandler.executeLiquidation",
     });
 
-    // The two named receivers should now hold non-zero claimable balances
-    // and they should be in a 30:20 ratio (= 3:2).
     const validatorBalance = await getClaimableFeeAmount(
       dataStore,
       ethUsdMarket.marketToken,
       wnt.address,
       validatorReceiver
     );
-    const insuranceBalance = await getClaimableFeeAmount(
-      dataStore,
-      ethUsdMarket.marketToken,
-      wnt.address,
-      insuranceFundAddress
+    const insuranceBalance = await dataStore.getUint(
+      keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address)
     );
 
-    expect(validatorBalance).gt(0);
-    expect(insuranceBalance).gt(0);
-    // 30% / 20% factors → validator/insurance ratio is 3/2
+    expect(validatorBalance, "validator claimable").gt(0);
+    expect(insuranceBalance, "insurance vault bucket").gt(0);
+    // 30% / 20% factors → validator/insurance ratio is 3/2 (same scale
+    // factor applied to both shares cancels in the ratio).
     expect(validatorBalance.mul(2)).eq(insuranceBalance.mul(3));
+
+    // Vault's physical token balance matches the bookkept reserve.
+    expect(await wnt.balanceOf(insuranceVault.address)).eq(insuranceBalance);
   });
 
-  // TODO: same insolvent-close issue as above.
-  it.skip("zero-address receivers are skipped on liquidation", async () => {
+  it("zero-address validator receiver is skipped, insurance still receives on liquidation", async () => {
     await dataStore.setAddress(keys.VALIDATOR_FEE_RECEIVER, "0x0000000000000000000000000000000000000000");
 
     await handleOrder(fixture, {
@@ -119,23 +113,22 @@ describe("Exchange.LiquidationFeeSplit", () => {
       market: ethUsdMarket,
       collateralToken: wnt,
       isLong: true,
-      minPrices: [expandDecimals(4000, 4), expandDecimals(1, 6)],
-      maxPrices: [expandDecimals(4000, 4), expandDecimals(1, 6)],
+      // Price $4500 → PnL -$20k, $30k collateral remaining; fees $60k → 50%
+      // partial payment, exercising _distributeInsolventShares scaling.
+      minPrices: [expandDecimals(4500, 4), expandDecimals(1, 6)],
+      maxPrices: [expandDecimals(4500, 4), expandDecimals(1, 6)],
       gasUsageLabel: "liquidationHandler.executeLiquidation",
     });
 
-    // validator address is zero → no credit; insurance still credits
+    // validator address is zero → no credit; insurance still credits the vault
     const validatorBalance = await getClaimableFeeAmount(
       dataStore,
       ethUsdMarket.marketToken,
       wnt.address,
       validatorReceiver
     );
-    const insuranceBalance = await getClaimableFeeAmount(
-      dataStore,
-      ethUsdMarket.marketToken,
-      wnt.address,
-      insuranceFundAddress
+    const insuranceBalance = await dataStore.getUint(
+      keys.insuranceFundBalanceKey(ethUsdMarket.marketToken, wnt.address)
     );
 
     expect(validatorBalance).eq(0);


### PR DESCRIPTION
Insolvent closes (full-size liquidation / ADL that can't fully pay) used to credit everything to the pool and zero all receivers , fixed by scaling each receiver's share by the recovered ratio instead of zeroing fees